### PR TITLE
refactor: プランA - クイックウィンリファクタリング

### DIFF
--- a/src/static/common/App.js
+++ b/src/static/common/App.js
@@ -541,7 +541,7 @@ export class App {
   }
 
   async handleMusicListResponse(res) {
-    console.log(res);
+    Logger.debug(res);
     if (res.status !== Parser.STATUS.SUCCESS) {
       await this.handleError(res);
       return;
@@ -560,7 +560,7 @@ export class App {
   }
 
   async handleMusicDetailResponse(res) {
-    console.log(res);
+    Logger.debug(res);
     // workaround:
     // A20PLUSのサイトには無い曲、A3のサイトには無い曲がそれぞれ存在するため
     // そのような曲のデータを取得しようとしてエラーになったときには
@@ -603,7 +603,7 @@ export class App {
   }
 
   async handleScoreListResponse(res) {
-    console.log(res);
+    Logger.debug(res);
     if (res.status !== Parser.STATUS.SUCCESS) {
       await this.handleError(res);
       return;
@@ -643,7 +643,7 @@ export class App {
   }
 
   async handleScoreDetailResponse(res) {
-    console.log(res);
+    Logger.debug(res);
     // workaround:
     // A20PLUSのサイトには無い曲、A3のサイトには無い曲がそれぞれ存在するため
     // そのような曲のデータを取得しようとしてエラーになったときには

--- a/src/static/common/Constants.js
+++ b/src/static/common/Constants.js
@@ -1,3 +1,7 @@
+let _scoreListUrl = null;
+let _musicDetailUrl = null;
+let _scoreDetailUrl = null;
+
 export class Constants {
   static get GAME_VERSION() {
     return {
@@ -76,6 +80,7 @@ export class Constants {
   }
 
   static get SCORE_LIST_URL() {
+    if (_scoreListUrl !== null) return _scoreListUrl;
     const result = {};
     result[this.GAME_VERSION.A20PLUS] = {};
     result[this.GAME_VERSION.A20PLUS][this.PLAY_MODE.SINGLE] = {};
@@ -116,11 +121,12 @@ export class Constants {
     result[this.GAME_VERSION.WORLD][this.PLAY_MODE.DOUBLE][this.MUSIC_TYPE.GRADE_PLUS] = '';
     result[this.GAME_VERSION.WORLD][this.PLAY_MODE.SINGLE][this.MUSIC_TYPE.GRADE_A3] = '';
     result[this.GAME_VERSION.WORLD][this.PLAY_MODE.DOUBLE][this.MUSIC_TYPE.GRADE_A3] = '';
-
-    return result;
+    _scoreListUrl = result;
+    return _scoreListUrl;
   }
 
   static get MUSIC_DETAIL_URL() {
+    if (_musicDetailUrl !== null) return _musicDetailUrl;
     const result = {};
     result[this.GAME_VERSION.A20PLUS] = {};
     result[this.GAME_VERSION.A20PLUS][this.MUSIC_TYPE.NORMAL] = 'https://p.eagate.573.jp/game/ddr/ddra20/p/playdata/music_detail.html?index=[musicId]';
@@ -140,10 +146,12 @@ export class Constants {
     result[this.GAME_VERSION.WORLD][this.MUSIC_TYPE.GRADE] = '';
     result[this.GAME_VERSION.WORLD][this.MUSIC_TYPE.GRADE_PLUS] = '';
     result[this.GAME_VERSION.WORLD][this.MUSIC_TYPE.GRADE_A3] = '';
-    return result;
+    _musicDetailUrl = result;
+    return _musicDetailUrl;
   }
 
   static get SCORE_DETAIL_URL() {
+    if (_scoreDetailUrl !== null) return _scoreDetailUrl;
     const result = {};
     result[this.GAME_VERSION.A20PLUS] = {};
     result[this.GAME_VERSION.A20PLUS][this.MUSIC_TYPE.NORMAL] = 'https://p.eagate.573.jp/game/ddr/ddra20/p/playdata/music_detail.html?index=[musicId]&diff=[difficulty]';
@@ -165,7 +173,8 @@ export class Constants {
     result[this.GAME_VERSION.WORLD][this.MUSIC_TYPE.GRADE] = '';
     result[this.GAME_VERSION.WORLD][this.MUSIC_TYPE.GRADE_PLUS] = '';
     result[this.GAME_VERSION.WORLD][this.MUSIC_TYPE.GRADE_A3] = '';
-    return result;
+    _scoreDetailUrl = result;
+    return _scoreDetailUrl;
   }
 
   static get PARSED_MUSIC_LIST_URL() {
@@ -516,18 +525,8 @@ export class Constants {
   }
 
   static get FLARE_RANK_SYMBOL() {
-    const result = {};
+    const result = Object.assign({}, this.FLARE_RANK_STRING);
     result[this.FLARE_RANK.NONE] = '';
-    result[this.FLARE_RANK.FLARE_1] = 'Ⅰ';
-    result[this.FLARE_RANK.FLARE_2] = 'Ⅱ';
-    result[this.FLARE_RANK.FLARE_3] = 'Ⅲ';
-    result[this.FLARE_RANK.FLARE_4] = 'Ⅳ';
-    result[this.FLARE_RANK.FLARE_5] = 'Ⅴ';
-    result[this.FLARE_RANK.FLARE_6] = 'Ⅵ';
-    result[this.FLARE_RANK.FLARE_7] = 'Ⅶ';
-    result[this.FLARE_RANK.FLARE_8] = 'Ⅷ';
-    result[this.FLARE_RANK.FLARE_9] = 'Ⅸ';
-    result[this.FLARE_RANK.FLARE_EX] = 'EX';
     return result;
   }
 

--- a/src/static/common/Logger.js
+++ b/src/static/common/Logger.js
@@ -40,7 +40,7 @@ export class Logger {
   }
 
   static debug(content) {
-    console.log(content);
+    console.debug(content);
     this.log(content, this.LOG_LEVEL.DEBUG);
   }
 }

--- a/src/static/common/MusicData.js
+++ b/src/static/common/MusicData.js
@@ -24,16 +24,23 @@ export class MusicData {
       return null;
     }
     const elements = encodedString.split('\t');
-    if (elements.length !== 13) {
+    const MUSIC_ID_INDEX = 0;
+    const TYPE_INDEX = 1;
+    const IS_DELETED_INDEX = 2;
+    const DIFFICULTY_START_INDEX = 3;
+    const DIFFICULTY_END_INDEX = 12;
+    const TITLE_INDEX = 12;
+    const ELEMENT_COUNT = 13;
+    if (elements.length !== ELEMENT_COUNT) {
       Logger.error(`MusicData.create invalid string: ${encodedString}`);
       return null;
     }
     const instance = new MusicData(
-      elements[0],
-      parseInt(elements[1], 10),
-      elements[12],
-      elements.slice(3, 12).map((element) => parseInt(element, 10)),
-      parseInt(elements[2], 10)
+      elements[MUSIC_ID_INDEX],
+      parseInt(elements[TYPE_INDEX], 10),
+      elements[TITLE_INDEX],
+      elements.slice(DIFFICULTY_START_INDEX, DIFFICULTY_END_INDEX).map((element) => parseInt(element, 10)),
+      parseInt(elements[IS_DELETED_INDEX], 10)
     );
     return instance;
   }

--- a/src/static/content_scripts/main.js
+++ b/src/static/content_scripts/main.js
@@ -43,7 +43,8 @@ function onMessage(message, sender, sendResponse) {
     (reason) => {
       // Logger may not be available if loadModules() failed before loading Logger
       console.error(reason);
-      sendResponse({ status: 1 }); // Parser.STATUS.UNKNOWN_ERROR
+      const PARSER_STATUS_UNKNOWN_ERROR = 1; // Parser.STATUS.UNKNOWN_ERROR
+      sendResponse({ status: PARSER_STATUS_UNKNOWN_ERROR });
     }
   );
   return true;


### PR DESCRIPTION
issue #546 リファクタリングプランAの実装です。

- App.js: console.log(res) を Logger.debug(res) に置換（4箇所）
- Logger.js: Logger.debug 内の console.log を console.debug に変更
- Constants.js: SCORE_LIST_URL / MUSIC_DETAIL_URL / SCORE_DETAIL_URL をキャッシュ化
- Constants.js: FLARE_RANK_SYMBOL を FLARE_RANK_STRING から派生させ重複削除
- content_scripts/main.js: マジックナンバー 1 を定数に置き換え
- MusicData.js: createFromString のマジックナンバーを名前付き定数で定義

Closes #546

Generated with [Claude Code](https://claude.ai/code)