### PR TITLE
test: テストされていない関数・コードパスにテストを追加

### DIFF
--- a/test/common/ChartData/ChartData.test.js
+++ b/test/common/ChartData/ChartData.test.js
@@ -1,0 +1,153 @@
+import { ChartData } from '../../../src/static/common/ChartData.js';
+import { MusicData } from '../../../src/static/common/MusicData.js';
+import { ScoreDetail } from '../../../src/static/common/ScoreDetail.js';
+import { Constants } from '../../../src/static/common/Constants.js';
+
+function makeChartData(playMode, difficulty, musicData = null, scoreDetail = null) {
+  const chartData = new ChartData('music001', playMode, difficulty);
+  chartData.musicData = musicData;
+  chartData.scoreDetail = scoreDetail;
+  return chartData;
+}
+
+test('ChartData.musicType returns UNKNOWN when musicData is null', () => {
+  const chartData = makeChartData(Constants.PLAY_MODE.SINGLE, Constants.DIFFICULTIES.EXPERT);
+  expect(chartData.musicType).toBe(Constants.MUSIC_TYPE.UNKNOWN);
+});
+
+test('ChartData.musicType returns musicData.type when musicData is set', () => {
+  const musicData = new MusicData('music001', Constants.MUSIC_TYPE.NORMAL, 'Title', [0, 5, 8, 12, 0, 0, 0, 0, 0], 0);
+  const chartData = makeChartData(Constants.PLAY_MODE.SINGLE, Constants.DIFFICULTIES.EXPERT, musicData);
+  expect(chartData.musicType).toBe(Constants.MUSIC_TYPE.NORMAL);
+});
+
+test('ChartData.title returns musicId when musicData is null', () => {
+  const chartData = makeChartData(Constants.PLAY_MODE.SINGLE, Constants.DIFFICULTIES.EXPERT);
+  expect(chartData.title).toBe('music001');
+});
+
+test('ChartData.title returns musicData.title when set', () => {
+  const musicData = new MusicData('music001', Constants.MUSIC_TYPE.NORMAL, 'Song Title', [0, 5, 8, 12, 0, 0, 0, 0, 0], 0);
+  const chartData = makeChartData(Constants.PLAY_MODE.SINGLE, Constants.DIFFICULTIES.EXPERT, musicData);
+  expect(chartData.title).toBe('Song Title');
+});
+
+test('ChartData.title returns musicId when musicData.title is empty', () => {
+  const musicData = new MusicData('music001', Constants.MUSIC_TYPE.NORMAL, '', [0, 5, 8, 12, 0, 0, 0, 0, 0], 0);
+  const chartData = makeChartData(Constants.PLAY_MODE.SINGLE, Constants.DIFFICULTIES.EXPERT, musicData);
+  expect(chartData.title).toBe('music001');
+});
+
+test('ChartData.level returns 0 when musicData is null', () => {
+  const chartData = makeChartData(Constants.PLAY_MODE.SINGLE, Constants.DIFFICULTIES.EXPERT);
+  expect(chartData.level).toBe(0);
+});
+
+test('ChartData.level returns correct level for given difficulty', () => {
+  const musicData = new MusicData('music001', Constants.MUSIC_TYPE.NORMAL, 'Title', [0, 5, 8, 12, 16, 0, 0, 0, 0], 0);
+  const chartData = makeChartData(Constants.PLAY_MODE.SINGLE, Constants.DIFFICULTIES.EXPERT, musicData);
+  expect(chartData.level).toBe(12);
+});
+
+test('ChartData.levelString returns "?" when level is 0', () => {
+  const chartData = makeChartData(Constants.PLAY_MODE.SINGLE, Constants.DIFFICULTIES.EXPERT);
+  expect(chartData.levelString).toBe('?');
+});
+
+test('ChartData.levelString returns level string when non-zero', () => {
+  const musicData = new MusicData('music001', Constants.MUSIC_TYPE.NORMAL, 'Title', [0, 5, 8, 12, 16, 0, 0, 0, 0], 0);
+  const chartData = makeChartData(Constants.PLAY_MODE.SINGLE, Constants.DIFFICULTIES.EXPERT, musicData);
+  expect(chartData.levelString).toBe('12');
+});
+
+test('ChartData.availability returns 0 when musicData is null', () => {
+  const chartData = makeChartData(Constants.PLAY_MODE.SINGLE, Constants.DIFFICULTIES.EXPERT);
+  expect(chartData.availability).toBe(0);
+});
+
+test('ChartData.availability returns 0 when music is not deleted', () => {
+  const musicData = new MusicData('music001', Constants.MUSIC_TYPE.NORMAL, 'Title', [0, 5, 8, 12, 0, 0, 0, 0, 0], 0);
+  const chartData = makeChartData(Constants.PLAY_MODE.SINGLE, Constants.DIFFICULTIES.EXPERT, musicData);
+  expect(chartData.availability).toBe(0);
+});
+
+test('ChartData.availability returns 2 when music is deleted without score', () => {
+  const musicData = new MusicData('music001', Constants.MUSIC_TYPE.NORMAL, 'Title', [0, 5, 8, 12, 0, 0, 0, 0, 0], 1);
+  const chartData = makeChartData(Constants.PLAY_MODE.SINGLE, Constants.DIFFICULTIES.EXPERT, musicData, null);
+  expect(chartData.availability).toBe(2);
+});
+
+test('ChartData.availability returns 1 when music is deleted with score', () => {
+  const musicData = new MusicData('music001', Constants.MUSIC_TYPE.NORMAL, 'Title', [0, 5, 8, 12, 0, 0, 0, 0, 0], 1);
+  const scoreDetail = ScoreDetail.createFromStorage({ score: 900000 });
+  const chartData = makeChartData(Constants.PLAY_MODE.SINGLE, Constants.DIFFICULTIES.EXPERT, musicData, scoreDetail);
+  expect(chartData.availability).toBe(1);
+});
+
+test('ChartData.score returns null when scoreDetail is null', () => {
+  const chartData = makeChartData(Constants.PLAY_MODE.SINGLE, Constants.DIFFICULTIES.EXPERT);
+  expect(chartData.score).toBeNull();
+});
+
+test('ChartData.score returns scoreDetail.score when set', () => {
+  const scoreDetail = ScoreDetail.createFromStorage({ score: 900000 });
+  const chartData = makeChartData(Constants.PLAY_MODE.SINGLE, Constants.DIFFICULTIES.EXPERT, null, scoreDetail);
+  expect(chartData.score).toBe(900000);
+});
+
+test('ChartData.clearType returns NO_PLAY when scoreDetail is null', () => {
+  const chartData = makeChartData(Constants.PLAY_MODE.SINGLE, Constants.DIFFICULTIES.EXPERT);
+  expect(chartData.clearType).toBe(Constants.CLEAR_TYPE.NO_PLAY);
+});
+
+test('ChartData.flareRank returns NONE when scoreDetail is null', () => {
+  const chartData = makeChartData(Constants.PLAY_MODE.SINGLE, Constants.DIFFICULTIES.EXPERT);
+  expect(chartData.flareRank).toBe(Constants.FLARE_RANK.NONE);
+});
+
+test('ChartData.flareRank returns actualFlareRank from scoreDetail', () => {
+  const scoreDetail = ScoreDetail.createFromStorage({ flareRank: Constants.FLARE_RANK.FLARE_EX });
+  const chartData = makeChartData(Constants.PLAY_MODE.SINGLE, Constants.DIFFICULTIES.EXPERT, null, scoreDetail);
+  expect(chartData.flareRank).toBe(Constants.FLARE_RANK.FLARE_EX);
+});
+
+test('ChartData.scoreString returns empty when scoreDetail is null', () => {
+  const chartData = makeChartData(Constants.PLAY_MODE.SINGLE, Constants.DIFFICULTIES.EXPERT);
+  expect(chartData.scoreString).toBe('');
+});
+
+test('ChartData.scoreString returns formatted score when set', () => {
+  const scoreDetail = ScoreDetail.createFromStorage({ score: 1000000 });
+  const chartData = makeChartData(Constants.PLAY_MODE.SINGLE, Constants.DIFFICULTIES.EXPERT, null, scoreDetail);
+  expect(chartData.scoreString).toBe((1000000).toLocaleString());
+});
+
+test('ChartData.difficultyClassString returns correct class string', () => {
+  const chartData = makeChartData(Constants.PLAY_MODE.SINGLE, Constants.DIFFICULTIES.EXPERT);
+  expect(chartData.difficultyClassString).toBe(Constants.DIFFICULTY_CLASS_STRING[Constants.DIFFICULTIES.EXPERT]);
+});
+
+test('ChartData.playModeSymbol returns correct symbol for SINGLE', () => {
+  const chartData = makeChartData(Constants.PLAY_MODE.SINGLE, Constants.DIFFICULTIES.EXPERT);
+  expect(chartData.playModeSymbol).toBe(Constants.PLAY_MODE_SYMBOL[Constants.PLAY_MODE.SINGLE]);
+});
+
+test('ChartData.playModeSymbol returns correct symbol for DOUBLE', () => {
+  const chartData = makeChartData(Constants.PLAY_MODE.DOUBLE, Constants.DIFFICULTIES.EXPERT);
+  expect(chartData.playModeSymbol).toBe(Constants.PLAY_MODE_SYMBOL[Constants.PLAY_MODE.DOUBLE]);
+});
+
+test('ChartData.playCount returns null when scoreDetail is null', () => {
+  const chartData = makeChartData(Constants.PLAY_MODE.SINGLE, Constants.DIFFICULTIES.EXPERT);
+  expect(chartData.playCount).toBeNull();
+});
+
+test('ChartData.clearCount returns null when scoreDetail is null', () => {
+  const chartData = makeChartData(Constants.PLAY_MODE.SINGLE, Constants.DIFFICULTIES.EXPERT);
+  expect(chartData.clearCount).toBeNull();
+});
+
+test('ChartData.maxCombo returns null when scoreDetail is null', () => {
+  const chartData = makeChartData(Constants.PLAY_MODE.SINGLE, Constants.DIFFICULTIES.EXPERT);
+  expect(chartData.maxCombo).toBeNull();
+});

--- a/test/common/ChartList/ChartList.compareChartData.test.js
+++ b/test/common/ChartList/ChartList.compareChartData.test.js
@@ -1,0 +1,50 @@
+import { ChartList } from '../../../src/static/common/ChartList.js';
+import { ChartData } from '../../../src/static/common/ChartData.js';
+import { Constants } from '../../../src/static/common/Constants.js';
+
+function makeChart(score, clearType) {
+  const chart = new ChartData('music001', Constants.PLAY_MODE.SINGLE, Constants.DIFFICULTIES.EXPERT);
+  chart._score = score;
+  chart._clearType = clearType;
+  // Override getters via scoreDetail-like object
+  Object.defineProperty(chart, 'score', { get: () => score });
+  Object.defineProperty(chart, 'clearType', { get: () => clearType });
+  return chart;
+}
+
+test('ChartList.compareChartData returns 0 when no sort conditions', () => {
+  const a = makeChart(900000, 3);
+  const b = makeChart(800000, 3);
+  expect(ChartList.compareChartData(a, b, [])).toBe(0);
+});
+
+test('ChartList.compareChartData asc: lower value comes first', () => {
+  const a = makeChart(800000, 3);
+  const b = makeChart(900000, 3);
+  const result = ChartList.compareChartData(a, b, [{ attribute: 'score', order: 'asc' }]);
+  expect(result).toBeLessThan(0);
+});
+
+test('ChartList.compareChartData desc: higher value comes first', () => {
+  const a = makeChart(900000, 3);
+  const b = makeChart(800000, 3);
+  const result = ChartList.compareChartData(a, b, [{ attribute: 'score', order: 'desc' }]);
+  expect(result).toBeLessThan(0);
+});
+
+test('ChartList.compareChartData falls through to next condition when equal', () => {
+  const a = makeChart(900000, 5);
+  const b = makeChart(900000, 3);
+  const result = ChartList.compareChartData(a, b, [
+    { attribute: 'score', order: 'desc' },
+    { attribute: 'clearType', order: 'desc' },
+  ]);
+  expect(result).toBeLessThan(0); // a has higher clearType, so a comes first in desc
+});
+
+test('ChartList.compareChartData null value sorts to end in asc', () => {
+  const a = { score: null };
+  const b = { score: 900000 };
+  const result = ChartList.compareChartData(a, b, [{ attribute: 'score', order: 'asc' }]);
+  expect(result).toBeLessThan(0); // null treated as less
+});

--- a/test/common/ChartList/ChartList.getFilteredAndSorted.test.js
+++ b/test/common/ChartList/ChartList.getFilteredAndSorted.test.js
@@ -1,0 +1,90 @@
+import { ChartList } from '../../../src/static/common/ChartList.js';
+import { ChartData } from '../../../src/static/common/ChartData.js';
+import { ScoreDetail } from '../../../src/static/common/ScoreDetail.js';
+import { Constants } from '../../../src/static/common/Constants.js';
+
+function makeChartData(musicId, playMode, difficulty, score, clearType, scoreRank) {
+  const chartData = new ChartData(musicId, playMode, difficulty);
+  if (score !== null) {
+    const detail = new ScoreDetail();
+    detail.score = score;
+    detail.clearType = clearType;
+    detail.scoreRank = scoreRank;
+    detail.flareRank = Constants.FLARE_RANK.NONE;
+    chartData.scoreDetail = detail;
+  }
+  return chartData;
+}
+
+test('ChartList.reset clears charts and statistics', () => {
+  const chartList = new ChartList();
+  chartList.addChartData(makeChartData('m1', 0, 3, 900000, 3, 14));
+  chartList.reset();
+  expect(chartList.charts).toHaveLength(0);
+  expect(chartList.statistics).toStrictEqual({});
+});
+
+test('ChartList.addChartData adds chart to list', () => {
+  const chartList = new ChartList();
+  chartList.addChartData(makeChartData('m1', 0, 3, 900000, 3, 14));
+  expect(chartList.charts).toHaveLength(1);
+});
+
+test('ChartList.getFilteredAndSorted returns all charts when no filter', () => {
+  const chartList = new ChartList();
+  chartList.addChartData(makeChartData('m1', 0, 3, 900000, Constants.CLEAR_TYPE.CLEAR, Constants.SCORE_RANK.AA));
+  chartList.addChartData(makeChartData('m2', 0, 3, 800000, Constants.CLEAR_TYPE.CLEAR, Constants.SCORE_RANK.A));
+
+  const allClearTypes = Object.values(Constants.CLEAR_TYPE);
+  const allPlayModes = Object.values(Constants.PLAY_MODE);
+  const filtered = chartList.getFilteredAndSorted([{ attribute: 'playMode', values: allPlayModes }], []);
+  expect(filtered.charts).toHaveLength(2);
+});
+
+test('ChartList.getFilteredAndSorted filters by playMode', () => {
+  const chartList = new ChartList();
+  chartList.addChartData(makeChartData('m1', Constants.PLAY_MODE.SINGLE, 3, 900000, Constants.CLEAR_TYPE.CLEAR, Constants.SCORE_RANK.AA));
+  chartList.addChartData(makeChartData('m2', Constants.PLAY_MODE.DOUBLE, 3, 800000, Constants.CLEAR_TYPE.CLEAR, Constants.SCORE_RANK.A));
+
+  const filtered = chartList.getFilteredAndSorted([{ attribute: 'playMode', values: [Constants.PLAY_MODE.SINGLE] }], []);
+  expect(filtered.charts).toHaveLength(1);
+  expect(filtered.charts[0].playMode).toBe(Constants.PLAY_MODE.SINGLE);
+});
+
+test('ChartList.getFilteredAndSorted sorts by score desc', () => {
+  const chartList = new ChartList();
+  chartList.addChartData(makeChartData('m1', 0, 3, 800000, Constants.CLEAR_TYPE.CLEAR, Constants.SCORE_RANK.A));
+  chartList.addChartData(makeChartData('m2', 0, 3, 900000, Constants.CLEAR_TYPE.CLEAR, Constants.SCORE_RANK.AA));
+
+  const allPlayModes = Object.values(Constants.PLAY_MODE);
+  const filtered = chartList.getFilteredAndSorted([{ attribute: 'playMode', values: allPlayModes }], [{ attribute: 'score', order: 'desc' }]);
+  expect(filtered.charts[0].score).toBe(900000);
+  expect(filtered.charts[1].score).toBe(800000);
+});
+
+test('ChartList.getFilteredAndSorted updates statistics', () => {
+  const chartList = new ChartList();
+  chartList.addChartData(makeChartData('m1', 0, 3, 900000, Constants.CLEAR_TYPE.CLEAR, Constants.SCORE_RANK.AA));
+
+  const allPlayModes = Object.values(Constants.PLAY_MODE);
+  const filtered = chartList.getFilteredAndSorted([{ attribute: 'playMode', values: allPlayModes }], []);
+  expect(filtered.statistics.score).not.toStrictEqual({});
+  expect(filtered.statistics.score.max.value).toBe(900000);
+});
+
+test('ChartList.updateStatistics with empty charts leaves score empty', () => {
+  const chartList = new ChartList();
+  chartList.updateStatistics();
+  expect(chartList.statistics.score).toStrictEqual({});
+});
+
+test('ChartList.updateStatistics counts clearTypes', () => {
+  const chartList = new ChartList();
+  chartList.addChartData(makeChartData('m1', 0, 3, 900000, Constants.CLEAR_TYPE.CLEAR, Constants.SCORE_RANK.AA));
+  chartList.addChartData(makeChartData('m2', 0, 3, 800000, Constants.CLEAR_TYPE.FAILED, Constants.SCORE_RANK.E));
+  chartList.updateStatistics();
+  const clearStat = chartList.statistics.clearType.find((s) => s.clearType === Constants.CLEAR_TYPE.CLEAR);
+  const failedStat = chartList.statistics.clearType.find((s) => s.clearType === Constants.CLEAR_TYPE.FAILED);
+  expect(clearStat.count).toBe(1);
+  expect(failedStat.count).toBe(1);
+});

--- a/test/common/ChartList/ChartList.scoreToScoreRank.allranks.test.js
+++ b/test/common/ChartList/ChartList.scoreToScoreRank.allranks.test.js
@@ -1,0 +1,85 @@
+import { ChartList } from '../../../src/static/common/ChartList.js';
+import { Constants } from '../../../src/static/common/Constants.js';
+
+describe('ChartList.scoreToScoreRank', () => {
+  let chartList;
+  beforeEach(() => {
+    chartList = new ChartList();
+  });
+
+  test('990000 → AAA', () => {
+    expect(chartList.scoreToScoreRank(990000)).toBe(Constants.SCORE_RANK.AAA);
+  });
+
+  test('1000000 → AAA', () => {
+    expect(chartList.scoreToScoreRank(1000000)).toBe(Constants.SCORE_RANK.AAA);
+  });
+
+  test('950000 → AA+', () => {
+    expect(chartList.scoreToScoreRank(950000)).toBe(Constants.SCORE_RANK.AA_PLUS);
+  });
+
+  test('960000 → AA+', () => {
+    expect(chartList.scoreToScoreRank(960000)).toBe(Constants.SCORE_RANK.AA_PLUS);
+  });
+
+  test('900000 → AA', () => {
+    expect(chartList.scoreToScoreRank(900000)).toBe(Constants.SCORE_RANK.AA);
+  });
+
+  test('910000 → AA', () => {
+    expect(chartList.scoreToScoreRank(910000)).toBe(Constants.SCORE_RANK.AA);
+  });
+
+  test('890000 → AA-', () => {
+    expect(chartList.scoreToScoreRank(890000)).toBe(Constants.SCORE_RANK.AA_MINUS);
+  });
+
+  test('850000 → A+', () => {
+    expect(chartList.scoreToScoreRank(850000)).toBe(Constants.SCORE_RANK.A_PLUS);
+  });
+
+  test('800000 → A', () => {
+    expect(chartList.scoreToScoreRank(800000)).toBe(Constants.SCORE_RANK.A);
+  });
+
+  test('790000 → A-', () => {
+    expect(chartList.scoreToScoreRank(790000)).toBe(Constants.SCORE_RANK.A_MINUS);
+  });
+
+  test('750000 → B+', () => {
+    expect(chartList.scoreToScoreRank(750000)).toBe(Constants.SCORE_RANK.B_PLUS);
+  });
+
+  test('700000 → B', () => {
+    expect(chartList.scoreToScoreRank(700000)).toBe(Constants.SCORE_RANK.B);
+  });
+
+  test('690000 → B-', () => {
+    expect(chartList.scoreToScoreRank(690000)).toBe(Constants.SCORE_RANK.B_MINUS);
+  });
+
+  test('650000 → C+', () => {
+    expect(chartList.scoreToScoreRank(650000)).toBe(Constants.SCORE_RANK.C_PLUS);
+  });
+
+  test('600000 → C', () => {
+    expect(chartList.scoreToScoreRank(600000)).toBe(Constants.SCORE_RANK.C);
+  });
+
+  test('590000 → C-', () => {
+    expect(chartList.scoreToScoreRank(590000)).toBe(Constants.SCORE_RANK.C_MINUS);
+  });
+
+  test('550000 → D+', () => {
+    expect(chartList.scoreToScoreRank(550000)).toBe(Constants.SCORE_RANK.D_PLUS);
+  });
+
+  test('0 → D', () => {
+    expect(chartList.scoreToScoreRank(0)).toBe(Constants.SCORE_RANK.D);
+  });
+
+  test('300000 → D', () => {
+    expect(chartList.scoreToScoreRank(300000)).toBe(Constants.SCORE_RANK.D);
+  });
+});

--- a/test/common/MusicData/MusicData.createEmptyData.test.js
+++ b/test/common/MusicData/MusicData.createEmptyData.test.js
@@ -1,0 +1,17 @@
+import { MusicData } from '../../../src/static/common/MusicData.js';
+import { Constants } from '../../../src/static/common/Constants.js';
+
+test('MusicData.createEmptyData creates an instance with expected defaults', () => {
+  const musicData = MusicData.createEmptyData('testId', Constants.MUSIC_TYPE.NORMAL);
+  expect(musicData.musicId).toBe('testId');
+  expect(musicData.type).toBe(Constants.MUSIC_TYPE.NORMAL);
+  expect(musicData.title).toBe('');
+  expect(musicData.difficulty).toStrictEqual([0, 0, 0, 0, 0, 0, 0, 0, 0]);
+  expect(musicData.isDeleted).toBe(0);
+});
+
+test('MusicData.createEmptyData with NONSTOP type', () => {
+  const musicData = MusicData.createEmptyData('nonstopId', Constants.MUSIC_TYPE.NONSTOP);
+  expect(musicData.musicId).toBe('nonstopId');
+  expect(musicData.type).toBe(Constants.MUSIC_TYPE.NONSTOP);
+});

--- a/test/common/MusicData/MusicData.createFromStorage.test.js
+++ b/test/common/MusicData/MusicData.createFromStorage.test.js
@@ -1,0 +1,30 @@
+import { MusicData } from '../../../src/static/common/MusicData.js';
+import { Constants } from '../../../src/static/common/Constants.js';
+
+test('MusicData.createFromStorage creates correct instance', () => {
+  const storageData = {
+    musicId: 'abc123',
+    type: Constants.MUSIC_TYPE.NORMAL,
+    title: 'Test Song',
+    difficulty: [0, 5, 8, 12, 0, 0, 0, 0, 0],
+    isDeleted: 0,
+  };
+  const musicData = MusicData.createFromStorage(storageData);
+  expect(musicData.musicId).toBe('abc123');
+  expect(musicData.type).toBe(Constants.MUSIC_TYPE.NORMAL);
+  expect(musicData.title).toBe('Test Song');
+  expect(musicData.difficulty).toStrictEqual([0, 5, 8, 12, 0, 0, 0, 0, 0]);
+  expect(musicData.isDeleted).toBe(0);
+});
+
+test('MusicData.createFromStorage with isDeleted=1', () => {
+  const storageData = {
+    musicId: 'deleted123',
+    type: Constants.MUSIC_TYPE.NORMAL,
+    title: 'Deleted Song',
+    difficulty: [0, 0, 0, 0, 0, 0, 0, 0, 0],
+    isDeleted: 1,
+  };
+  const musicData = MusicData.createFromStorage(storageData);
+  expect(musicData.isDeleted).toBe(1);
+});

--- a/test/common/MusicData/MusicData.createFromString.test.js
+++ b/test/common/MusicData/MusicData.createFromString.test.js
@@ -1,0 +1,34 @@
+import { MusicData } from '../../../src/static/common/MusicData.js';
+import { Constants } from '../../../src/static/common/Constants.js';
+
+test('MusicData.createFromString with valid string', () => {
+  // format: musicId \t type \t isDeleted \t diff[0..8] \t title  (13 elements)
+  const encodedString = '91qD6DbDqi96qbIO66oboliPD8IPP6io\t0\t0\t3\t7\t11\t13\t16\t7\t11\t13\t16\t輪廻転生';
+  const musicData = MusicData.createFromString(encodedString);
+  expect(musicData).not.toBeNull();
+  expect(musicData.musicId).toBe('91qD6DbDqi96qbIO66oboliPD8IPP6io');
+  expect(musicData.type).toBe(Constants.MUSIC_TYPE.NORMAL);
+  expect(musicData.isDeleted).toBe(0);
+  expect(musicData.difficulty).toStrictEqual([3, 7, 11, 13, 16, 7, 11, 13, 16]);
+  expect(musicData.title).toBe('輪廻転生');
+});
+
+test('MusicData.createFromString with empty string returns null', () => {
+  expect(MusicData.createFromString('')).toBeNull();
+});
+
+test('MusicData.createFromString with whitespace-only string returns null', () => {
+  expect(MusicData.createFromString('   ')).toBeNull();
+});
+
+test('MusicData.createFromString with wrong element count returns null', () => {
+  const shortString = 'id\t0\t0\t1\t2';
+  expect(MusicData.createFromString(shortString)).toBeNull();
+});
+
+test('MusicData.createFromString with isDeleted=1', () => {
+  const encodedString = 'musicId001\t0\t1\t3\t7\t11\t13\t16\t7\t11\t13\t16\tSong Title';
+  const musicData = MusicData.createFromString(encodedString);
+  expect(musicData).not.toBeNull();
+  expect(musicData.isDeleted).toBe(1);
+});

--- a/test/common/MusicData/MusicData.encodedString.test.js
+++ b/test/common/MusicData/MusicData.encodedString.test.js
@@ -1,0 +1,26 @@
+import { MusicData } from '../../../src/static/common/MusicData.js';
+import { Constants } from '../../../src/static/common/Constants.js';
+
+test('MusicData.encodedString produces tab-separated string matching createFromString input', () => {
+  const encodedString = '91qD6DbDqi96qbIO66oboliPD8IPP6io\t0\t0\t3\t7\t11\t13\t16\t7\t11\t13\t16\t輪廻転生';
+  const musicData = MusicData.createFromString(encodedString);
+  expect(musicData.encodedString).toBe(encodedString);
+});
+
+test('MusicData.encodedString includes musicId, type, isDeleted, difficulty, title in order', () => {
+  const musicData = new MusicData('testId', Constants.MUSIC_TYPE.NORMAL, 'Test Song', [0, 5, 8, 12, 0, 0, 0, 0, 0], 0);
+  const parts = musicData.encodedString.split('\t');
+  expect(parts[0]).toBe('testId');
+  expect(parts[1]).toBe('0'); // NORMAL
+  expect(parts[2]).toBe('0'); // isDeleted
+  expect(parts[3]).toBe('0');
+  expect(parts[4]).toBe('5');
+  expect(parts[5]).toBe('8');
+  expect(parts[6]).toBe('12');
+  expect(parts[7]).toBe('0');
+  expect(parts[8]).toBe('0');
+  expect(parts[9]).toBe('0');
+  expect(parts[10]).toBe('0');
+  expect(parts[11]).toBe('0');
+  expect(parts[12]).toBe('Test Song');
+});

--- a/test/common/MusicData/MusicData.getLevel.test.js
+++ b/test/common/MusicData/MusicData.getLevel.test.js
@@ -1,0 +1,26 @@
+import { MusicData } from '../../../src/static/common/MusicData.js';
+import { Constants } from '../../../src/static/common/Constants.js';
+
+test('MusicData.getLevel returns correct level for given index', () => {
+  const musicData = new MusicData('id', Constants.MUSIC_TYPE.NORMAL, 'Title', [0, 5, 8, 12, 0, 0, 7, 11, 0], 0);
+  expect(musicData.getLevel(1)).toBe(5);
+  expect(musicData.getLevel(2)).toBe(8);
+  expect(musicData.getLevel(3)).toBe(12);
+});
+
+test('MusicData.getLevel returns 0 for absent difficulty', () => {
+  const musicData = new MusicData('id', Constants.MUSIC_TYPE.NORMAL, 'Title', [0, 0, 0, 0, 0, 0, 0, 0, 0], 0);
+  expect(musicData.getLevel(0)).toBe(0);
+});
+
+test('MusicData.hasDifficulty returns true when difficulty is non-zero', () => {
+  const musicData = new MusicData('id', Constants.MUSIC_TYPE.NORMAL, 'Title', [0, 5, 8, 12, 0, 0, 0, 0, 0], 0);
+  expect(musicData.hasDifficulty(1)).toBe(true);
+  expect(musicData.hasDifficulty(2)).toBe(true);
+});
+
+test('MusicData.hasDifficulty returns false when difficulty is zero', () => {
+  const musicData = new MusicData('id', Constants.MUSIC_TYPE.NORMAL, 'Title', [0, 5, 8, 12, 0, 0, 0, 0, 0], 0);
+  expect(musicData.hasDifficulty(0)).toBe(false);
+  expect(musicData.hasDifficulty(4)).toBe(false);
+});

--- a/test/common/MusicList/MusicList.applyMusicData.test.js
+++ b/test/common/MusicList/MusicList.applyMusicData.test.js
@@ -1,0 +1,76 @@
+import { MusicList } from '../../../src/static/common/MusicList.js';
+import { MusicData } from '../../../src/static/common/MusicData.js';
+import { Constants } from '../../../src/static/common/Constants.js';
+
+// mock chrome API
+global.chrome = {
+  runtime: {
+    sendMessage: () => {},
+  },
+};
+
+test('MusicList.applyMusicData adds new music and returns true', () => {
+  const musicList = new MusicList();
+  const musicData = new MusicData('music001', Constants.MUSIC_TYPE.NORMAL, 'Song A', [0, 5, 8, 12, 0, 0, 0, 0, 0], 0);
+  const result = musicList.applyMusicData(musicData);
+  expect(result).toBe(true);
+  expect(musicList.hasMusic('music001')).toBe(true);
+});
+
+test('MusicList.applyMusicData merges existing music when changed and returns true', () => {
+  const musicList = new MusicList();
+  const musicData1 = new MusicData('music001', Constants.MUSIC_TYPE.NORMAL, '', [0, 5, 8, 12, 0, 0, 0, 0, 0], 0);
+  musicList.applyMusicData(musicData1);
+  const musicData2 = new MusicData('music001', Constants.MUSIC_TYPE.NORMAL, 'Song A', [0, 5, 8, 12, 0, 0, 0, 0, 0], 0);
+  const result = musicList.applyMusicData(musicData2);
+  expect(result).toBe(true);
+  expect(musicList.getMusicDataById('music001').title).toBe('Song A');
+});
+
+test('MusicList.applyMusicData returns false when no change occurs', () => {
+  const musicList = new MusicList();
+  const musicData1 = new MusicData('music001', Constants.MUSIC_TYPE.NORMAL, 'Song A', [0, 5, 8, 12, 0, 0, 0, 0, 0], 0);
+  musicList.applyMusicData(musicData1);
+  const musicData2 = new MusicData('music001', Constants.MUSIC_TYPE.NORMAL, 'Song A', [0, 5, 8, 12, 0, 0, 0, 0, 0], 0);
+  const result = musicList.applyMusicData(musicData2);
+  expect(result).toBe(false);
+});
+
+test('MusicList.applyMusicData removes music when isDeleted=2 and music exists, returns true', () => {
+  const musicList = new MusicList();
+  const musicData1 = new MusicData('music001', Constants.MUSIC_TYPE.NORMAL, 'Song A', [0, 5, 8, 12, 0, 0, 0, 0, 0], 0);
+  musicList.applyMusicData(musicData1);
+  const musicDataDeleted = new MusicData('music001', Constants.MUSIC_TYPE.NORMAL, 'Song A', [0, 5, 8, 12, 0, 0, 0, 0, 0], 2);
+  const result = musicList.applyMusicData(musicDataDeleted);
+  expect(result).toBe(true);
+  expect(musicList.hasMusic('music001')).toBe(false);
+});
+
+test('MusicList.applyMusicData returns false when isDeleted=2 but music does not exist', () => {
+  const musicList = new MusicList();
+  const musicDataDeleted = new MusicData('nonexistent', Constants.MUSIC_TYPE.NORMAL, '', [0, 0, 0, 0, 0, 0, 0, 0, 0], 2);
+  const result = musicList.applyMusicData(musicDataDeleted);
+  expect(result).toBe(false);
+});
+
+test('MusicList.applyObject creates from storage object and applies', () => {
+  const musicList = new MusicList();
+  const object = {
+    musicId: 'music001',
+    type: Constants.MUSIC_TYPE.NORMAL,
+    title: 'Song A',
+    difficulty: [0, 5, 8, 12, 0, 0, 0, 0, 0],
+    isDeleted: 0,
+  };
+  const result = musicList.applyObject(object);
+  expect(result).toBe(true);
+  expect(musicList.hasMusic('music001')).toBe(true);
+});
+
+test('MusicList.applyEncodedString applies from encoded string', () => {
+  const musicList = new MusicList();
+  const encodedString = '91qD6DbDqi96qbIO66oboliPD8IPP6io\t0\t0\t3\t7\t11\t13\t16\t7\t11\t13\t16\t輪廻転生';
+  const result = musicList.applyEncodedString(encodedString);
+  expect(result).toBe(true);
+  expect(musicList.hasMusic('91qD6DbDqi96qbIO66oboliPD8IPP6io')).toBe(true);
+});

--- a/test/common/MusicList/MusicList.createFromStorage.test.js
+++ b/test/common/MusicList/MusicList.createFromStorage.test.js
@@ -1,0 +1,39 @@
+import { MusicList } from '../../../src/static/common/MusicList.js';
+import { MusicData } from '../../../src/static/common/MusicData.js';
+import { Constants } from '../../../src/static/common/Constants.js';
+
+// mock chrome API
+global.chrome = {
+  runtime: {
+    sendMessage: () => {},
+  },
+};
+
+test('MusicList.createFromStorage creates MusicList from storage data', () => {
+  const storageData = {
+    music001: {
+      musicId: 'music001',
+      type: Constants.MUSIC_TYPE.NORMAL,
+      title: 'Song A',
+      difficulty: [0, 5, 8, 12, 0, 0, 0, 0, 0],
+      isDeleted: 0,
+    },
+    music002: {
+      musicId: 'music002',
+      type: Constants.MUSIC_TYPE.NORMAL,
+      title: 'Song B',
+      difficulty: [0, 7, 10, 14, 0, 0, 0, 0, 0],
+      isDeleted: 0,
+    },
+  };
+  const musicList = MusicList.createFromStorage(storageData);
+  expect(musicList.hasMusic('music001')).toBe(true);
+  expect(musicList.hasMusic('music002')).toBe(true);
+  expect(musicList.getMusicDataById('music001').title).toBe('Song A');
+  expect(musicList.getMusicDataById('music002').title).toBe('Song B');
+});
+
+test('MusicList.createFromStorage with empty storage creates empty MusicList', () => {
+  const musicList = MusicList.createFromStorage({});
+  expect(musicList.musicIds).toHaveLength(0);
+});

--- a/test/common/MusicList/MusicList.hasMusic.removeMusic.test.js
+++ b/test/common/MusicList/MusicList.hasMusic.removeMusic.test.js
@@ -1,0 +1,69 @@
+import { MusicList } from '../../../src/static/common/MusicList.js';
+import { MusicData } from '../../../src/static/common/MusicData.js';
+import { Constants } from '../../../src/static/common/Constants.js';
+
+// mock chrome API
+global.chrome = {
+  runtime: {
+    sendMessage: () => {},
+  },
+};
+
+function createMusicList(ids) {
+  const musicList = new MusicList();
+  ids.forEach((id) => {
+    musicList.applyMusicData(new MusicData(id, Constants.MUSIC_TYPE.NORMAL, `Title ${id}`, [0, 5, 8, 12, 0, 0, 0, 0, 0], 0));
+  });
+  return musicList;
+}
+
+test('MusicList.hasMusic returns true for existing music', () => {
+  const musicList = createMusicList(['music001']);
+  expect(musicList.hasMusic('music001')).toBe(true);
+});
+
+test('MusicList.hasMusic returns false for non-existing music', () => {
+  const musicList = createMusicList(['music001']);
+  expect(musicList.hasMusic('music999')).toBe(false);
+});
+
+test('MusicList.removeMusic removes existing music and returns true', () => {
+  const musicList = createMusicList(['music001']);
+  const result = musicList.removeMusic('music001');
+  expect(result).toBe(true);
+  expect(musicList.hasMusic('music001')).toBe(false);
+});
+
+test('MusicList.removeMusic returns false for non-existing music', () => {
+  const musicList = new MusicList();
+  const result = musicList.removeMusic('nonexistent');
+  expect(result).toBe(false);
+});
+
+test('MusicList.musicIds returns all music IDs', () => {
+  const musicList = createMusicList(['music001', 'music002', 'music003']);
+  expect(musicList.musicIds).toHaveLength(3);
+  expect(musicList.musicIds).toContain('music001');
+  expect(musicList.musicIds).toContain('music002');
+  expect(musicList.musicIds).toContain('music003');
+});
+
+test('MusicList.musicIds returns empty array for empty list', () => {
+  const musicList = new MusicList();
+  expect(musicList.musicIds).toHaveLength(0);
+});
+
+test('MusicList.toStorageData returns musics object', () => {
+  const musicList = createMusicList(['music001', 'music002']);
+  const storageData = musicList.toStorageData();
+  expect(Object.prototype.hasOwnProperty.call(storageData, 'music001')).toBe(true);
+  expect(Object.prototype.hasOwnProperty.call(storageData, 'music002')).toBe(true);
+});
+
+test('MusicList.getMusicDataById returns correct MusicData', () => {
+  const musicList = createMusicList(['music001']);
+  const musicData = musicList.getMusicDataById('music001');
+  expect(musicData).not.toBeNull();
+  expect(musicData.musicId).toBe('music001');
+  expect(musicData.title).toBe('Title music001');
+});

--- a/test/common/ScoreData/ScoreData.test.js
+++ b/test/common/ScoreData/ScoreData.test.js
@@ -1,0 +1,107 @@
+import { ScoreData } from '../../../src/static/common/ScoreData.js';
+import { ScoreDetail } from '../../../src/static/common/ScoreDetail.js';
+import { Constants } from '../../../src/static/common/Constants.js';
+
+test('ScoreData.createFromStorage creates instance with musicId and musicType', () => {
+  const storageData = {
+    musicId: 'music001',
+    musicType: Constants.MUSIC_TYPE.NORMAL,
+    difficulty: {},
+  };
+  const scoreData = ScoreData.createFromStorage(storageData);
+  expect(scoreData.musicId).toBe('music001');
+  expect(scoreData.musicType).toBe(Constants.MUSIC_TYPE.NORMAL);
+});
+
+test('ScoreData.createFromStorage defaults musicType to UNKNOWN when not set', () => {
+  const storageData = {
+    musicId: 'music001',
+    difficulty: {},
+  };
+  const scoreData = ScoreData.createFromStorage(storageData);
+  expect(scoreData.musicType).toBe(Constants.MUSIC_TYPE.UNKNOWN);
+});
+
+test('ScoreData.createFromStorage restores ScoreDetail per difficulty', () => {
+  const storageData = {
+    musicId: 'music001',
+    difficulty: {
+      3: { score: 900000, scoreRank: 14 },
+    },
+  };
+  const scoreData = ScoreData.createFromStorage(storageData);
+  expect(scoreData.hasDifficulty(3)).toBe(true);
+  expect(scoreData.getScoreDetailByDifficulty(3).score).toBe(900000);
+});
+
+test('ScoreData.hasDifficulty returns false for non-existing difficulty', () => {
+  const scoreData = new ScoreData('music001');
+  expect(scoreData.hasDifficulty(3)).toBe(false);
+});
+
+test('ScoreData.difficulties returns list of difficulty values', () => {
+  const scoreData = new ScoreData('music001');
+  const detail = ScoreDetail.createFromStorage({ score: 900000 });
+  scoreData.applyScoreDetail(3, detail);
+  scoreData.applyScoreDetail(4, detail);
+  expect(scoreData.difficulties).toContain('3');
+  expect(scoreData.difficulties).toContain('4');
+  expect(scoreData.difficulties).toHaveLength(2);
+});
+
+test('ScoreData.applyScoreDetail adds new difficulty with diff', () => {
+  const scoreData = new ScoreData('music001');
+  const detail = ScoreDetail.createFromStorage({ score: 900000 });
+  const diff = scoreData.applyScoreDetail(3, detail);
+  expect(diff).not.toBeNull();
+  expect(scoreData.hasDifficulty(3)).toBe(true);
+  expect(diff.after.score).toBe(900000);
+  expect(diff.before).toBeNull();
+});
+
+test('ScoreData.applyScoreDetail merges existing difficulty', () => {
+  const scoreData = new ScoreData('music001');
+  const detail1 = ScoreDetail.createFromStorage({ score: 900000 });
+  scoreData.applyScoreDetail(3, detail1);
+  const detail2 = ScoreDetail.createFromStorage({ score: 950000 });
+  const diff = scoreData.applyScoreDetail(3, detail2);
+  // merge should update score
+  expect(scoreData.getScoreDetailByDifficulty(3).score).toBe(950000);
+  expect(diff).not.toBeNull();
+});
+
+test('ScoreData.applyScoreDetail returns null when no change', () => {
+  const scoreData = new ScoreData('music001');
+  const detail = ScoreDetail.createFromStorage({ score: 900000 });
+  scoreData.applyScoreDetail(3, detail);
+  const sameDetail = ScoreDetail.createFromStorage({ score: 900000 });
+  const diff = scoreData.applyScoreDetail(3, sameDetail);
+  expect(diff).toBeNull();
+});
+
+test('ScoreData.merge applies all difficulties from another ScoreData', () => {
+  const base = new ScoreData('music001');
+  const detail1 = ScoreDetail.createFromStorage({ score: 800000 });
+  base.applyScoreDetail(3, detail1);
+
+  const other = new ScoreData('music001');
+  other.musicType = Constants.MUSIC_TYPE.NORMAL;
+  const detail2 = ScoreDetail.createFromStorage({ score: 900000 });
+  other.applyScoreDetail(3, detail2);
+  other.applyScoreDetail(4, ScoreDetail.createFromStorage({ score: 850000 }));
+
+  const diffs = base.merge(other);
+  expect(base.musicType).toBe(Constants.MUSIC_TYPE.NORMAL);
+  expect(base.getScoreDetailByDifficulty(3).score).toBe(900000);
+  expect(base.hasDifficulty(4)).toBe(true);
+  expect(diffs.length).toBeGreaterThan(0);
+});
+
+test('ScoreData.merge does not update musicType when UNKNOWN', () => {
+  const base = new ScoreData('music001');
+  base.musicType = Constants.MUSIC_TYPE.NORMAL;
+  const other = new ScoreData('music001');
+  // other.musicType defaults to UNKNOWN
+  base.merge(other);
+  expect(base.musicType).toBe(Constants.MUSIC_TYPE.NORMAL);
+});

--- a/test/common/ScoreDetail/ScoreDetail.actualFlareRank.test.js
+++ b/test/common/ScoreDetail/ScoreDetail.actualFlareRank.test.js
@@ -1,0 +1,17 @@
+import { ScoreDetail } from '../../../src/static/common/ScoreDetail.js';
+import { Constants } from '../../../src/static/common/Constants.js';
+
+test('ScoreDetail.actualFlareRank returns NONE when flareRank is null', () => {
+  const scoreDetail = ScoreDetail.createFromStorage({});
+  expect(scoreDetail.actualFlareRank).toBe(Constants.FLARE_RANK.NONE);
+});
+
+test('ScoreDetail.actualFlareRank returns the stored flareRank when set', () => {
+  const scoreDetail = ScoreDetail.createFromStorage({ flareRank: Constants.FLARE_RANK.FLARE_EX });
+  expect(scoreDetail.actualFlareRank).toBe(Constants.FLARE_RANK.FLARE_EX);
+});
+
+test('ScoreDetail.actualFlareRank returns FLARE_5 when set', () => {
+  const scoreDetail = ScoreDetail.createFromStorage({ flareRank: Constants.FLARE_RANK.FLARE_5 });
+  expect(scoreDetail.actualFlareRank).toBe(Constants.FLARE_RANK.FLARE_5);
+});

--- a/test/common/ScoreDetail/ScoreDetail.actualScoreRank.test.js
+++ b/test/common/ScoreDetail/ScoreDetail.actualScoreRank.test.js
@@ -1,0 +1,17 @@
+import { ScoreDetail } from '../../../src/static/common/ScoreDetail.js';
+import { Constants } from '../../../src/static/common/Constants.js';
+
+test('ScoreDetail.actualScoreRank returns NO_PLAY when scoreRank is null', () => {
+  const scoreDetail = ScoreDetail.createFromStorage({});
+  expect(scoreDetail.actualScoreRank).toBe(Constants.SCORE_RANK.NO_PLAY);
+});
+
+test('ScoreDetail.actualScoreRank returns the stored scoreRank when set', () => {
+  const scoreDetail = ScoreDetail.createFromStorage({ scoreRank: Constants.SCORE_RANK.AAA });
+  expect(scoreDetail.actualScoreRank).toBe(Constants.SCORE_RANK.AAA);
+});
+
+test('ScoreDetail.actualScoreRank returns E rank when set', () => {
+  const scoreDetail = ScoreDetail.createFromStorage({ scoreRank: Constants.SCORE_RANK.E });
+  expect(scoreDetail.actualScoreRank).toBe(Constants.SCORE_RANK.E);
+});

--- a/test/common/ScoreDetail/ScoreDetail.clone.test.js
+++ b/test/common/ScoreDetail/ScoreDetail.clone.test.js
@@ -1,0 +1,25 @@
+import { ScoreDetail } from '../../../src/static/common/ScoreDetail.js';
+
+test('ScoreDetail.clone creates an independent copy', () => {
+  const original = ScoreDetail.createFromStorage({
+    score: 900000,
+    scoreRank: 14,
+    clearType: 3,
+    playCount: 5,
+    clearCount: 3,
+    maxCombo: 100,
+  });
+  const cloned = original.clone();
+  expect(cloned).toStrictEqual(original);
+  // Mutate the clone and verify the original is unaffected
+  cloned.score = 0;
+  expect(original.score).toBe(900000);
+});
+
+test('ScoreDetail.clone copies null values correctly', () => {
+  const original = ScoreDetail.createFromStorage({});
+  const cloned = original.clone();
+  expect(cloned.score).toBeNull();
+  expect(cloned.scoreRank).toBeNull();
+  expect(cloned.clearType).toBeNull();
+});

--- a/test/common/ScoreDiff/ScoreDiff.test.js
+++ b/test/common/ScoreDiff/ScoreDiff.test.js
@@ -1,0 +1,164 @@
+import { ScoreDiff } from '../../../src/static/common/ScoreDiff.js';
+import { ScoreDetail } from '../../../src/static/common/ScoreDetail.js';
+import { ScoreData } from '../../../src/static/common/ScoreData.js';
+import { MusicData } from '../../../src/static/common/MusicData.js';
+import { Constants } from '../../../src/static/common/Constants.js';
+
+test('ScoreDiff.createFromScoreDetail sets before and after', () => {
+  const before = ScoreDetail.createFromStorage({ score: 800000 });
+  const after = ScoreDetail.createFromStorage({ score: 900000 });
+  const diff = ScoreDiff.createFromScoreDetail(before, after);
+  expect(diff.before.score).toBe(800000);
+  expect(diff.after.score).toBe(900000);
+});
+
+test('ScoreDiff.createFromScoreDetail with null before', () => {
+  const after = ScoreDetail.createFromStorage({ score: 900000 });
+  const diff = ScoreDiff.createFromScoreDetail(null, after);
+  expect(diff.before).toBeNull();
+  expect(diff.after.score).toBe(900000);
+});
+
+test('ScoreDiff.createFromStorage restores before and after', () => {
+  const storageData = {
+    musicId: 'music001',
+    difficultyValue: 3,
+    before: { score: 800000 },
+    after: { score: 900000 },
+  };
+  const diff = ScoreDiff.createFromStorage(storageData);
+  expect(diff.musicId).toBe('music001');
+  expect(diff.difficultyValue).toBe(3);
+  expect(diff.before.score).toBe(800000);
+  expect(diff.after.score).toBe(900000);
+});
+
+test('ScoreDiff.createFromStorage with null before', () => {
+  const storageData = {
+    musicId: 'music001',
+    difficultyValue: 3,
+    before: null,
+    after: { score: 900000 },
+  };
+  const diff = ScoreDiff.createFromStorage(storageData);
+  expect(diff.before).toBeNull();
+});
+
+test('ScoreDiff.createMultiFromStorage creates multiple diffs', () => {
+  const storageData = [
+    { musicId: 'music001', difficultyValue: 3, before: null, after: { score: 900000 } },
+    { musicId: 'music001', difficultyValue: 4, before: { score: 800000 }, after: { score: 850000 } },
+  ];
+  const diffs = ScoreDiff.createMultiFromStorage(storageData);
+  expect(diffs).toHaveLength(2);
+  expect(diffs[0].difficultyValue).toBe(3);
+  expect(diffs[1].difficultyValue).toBe(4);
+});
+
+test('ScoreDiff.createMultiFromScoreData creates diffs for each difficulty', () => {
+  const scoreData = new ScoreData('music001');
+  scoreData.applyScoreDetail(3, ScoreDetail.createFromStorage({ score: 900000 }));
+  scoreData.applyScoreDetail(4, ScoreDetail.createFromStorage({ score: 850000 }));
+  const diffs = ScoreDiff.createMultiFromScoreData(scoreData);
+  expect(diffs).toHaveLength(2);
+  diffs.forEach((diff) => {
+    expect(diff.musicId).toBe('music001');
+    expect(diff.before).toBeNull();
+  });
+});
+
+test('ScoreDiff.title returns musicId when musicData is null', () => {
+  const diff = new ScoreDiff();
+  diff.musicId = 'music001';
+  diff.musicData = null;
+  expect(diff.title).toBe('music001');
+});
+
+test('ScoreDiff.title returns musicData.title when musicData is set', () => {
+  const diff = new ScoreDiff();
+  diff.musicId = 'music001';
+  diff.musicData = new MusicData('music001', Constants.MUSIC_TYPE.NORMAL, 'Song Title', [0, 0, 0, 0, 0, 0, 0, 0, 0], 0);
+  expect(diff.title).toBe('Song Title');
+});
+
+test('ScoreDiff.playMode returns correct play mode from difficultyValue', () => {
+  const diff = new ScoreDiff();
+  diff.difficultyValue = 3; // ESP (SINGLE)
+  expect(diff.playMode).toBe(Constants.PLAY_MODE.SINGLE);
+  diff.difficultyValue = 7; // EDP (DOUBLE)
+  expect(diff.playMode).toBe(Constants.PLAY_MODE.DOUBLE);
+});
+
+test('ScoreDiff.difficulty returns correct difficulty from difficultyValue', () => {
+  const diff = new ScoreDiff();
+  diff.difficultyValue = 3; // ESP
+  expect(diff.difficulty).toBe(3);
+  diff.difficultyValue = 7; // EDP => difficulty 3
+  expect(diff.difficulty).toBe(3);
+});
+
+test('ScoreDiff.level returns 0 when musicData is null', () => {
+  const diff = new ScoreDiff();
+  diff.musicData = null;
+  diff.difficultyValue = 3;
+  expect(diff.level).toBe(0);
+});
+
+test('ScoreDiff.levelString returns "?" when level is 0', () => {
+  const diff = new ScoreDiff();
+  diff.musicData = null;
+  expect(diff.levelString).toBe('?');
+});
+
+test('ScoreDiff.levelString returns level as string when level is non-zero', () => {
+  const diff = new ScoreDiff();
+  diff.difficultyValue = 3;
+  diff.musicData = new MusicData('music001', Constants.MUSIC_TYPE.NORMAL, 'Title', [0, 5, 8, 12, 0, 0, 0, 0, 0], 0);
+  expect(diff.levelString).toBe('12');
+});
+
+test('ScoreDiff before/after getter returns null when before/after is null', () => {
+  const diff = new ScoreDiff();
+  diff.before = null;
+  diff.after = null;
+  expect(diff.beforeScore).toBeNull();
+  expect(diff.afterScore).toBeNull();
+  expect(diff.beforeScoreRank).toBeNull();
+  expect(diff.afterScoreRank).toBeNull();
+  expect(diff.beforeClearType).toBeNull();
+  expect(diff.afterClearType).toBeNull();
+});
+
+test('ScoreDiff beforeScoreString returns empty string when beforeScore is null', () => {
+  const diff = new ScoreDiff();
+  diff.before = null;
+  expect(diff.beforeScoreString).toBe('');
+});
+
+test('ScoreDiff afterScoreString returns formatted score when set', () => {
+  const after = ScoreDetail.createFromStorage({ score: 1000000, scoreRank: Constants.SCORE_RANK.AAA });
+  const diff = ScoreDiff.createFromScoreDetail(null, after);
+  expect(diff.afterScoreString).toBe((1000000).toLocaleString());
+});
+
+test('ScoreDiff.playModeSymbol returns correct symbol', () => {
+  const diff = new ScoreDiff();
+  diff.difficultyValue = 3; // SINGLE
+  expect(diff.playModeSymbol).toBe(Constants.PLAY_MODE_SYMBOL[Constants.PLAY_MODE.SINGLE]);
+  diff.difficultyValue = 7; // DOUBLE
+  expect(diff.playModeSymbol).toBe(Constants.PLAY_MODE_SYMBOL[Constants.PLAY_MODE.DOUBLE]);
+});
+
+test('ScoreDiff.difficultyClassString returns correct class string', () => {
+  const diff = new ScoreDiff();
+  diff.difficultyValue = 3; // ESP
+  expect(diff.difficultyClassString).toBe(Constants.DIFFICULTY_CLASS_STRING[3]);
+});
+
+test('ScoreDiff.beforeClearTypeString and afterClearTypeString return empty when null', () => {
+  const diff = new ScoreDiff();
+  diff.before = null;
+  diff.after = null;
+  expect(diff.beforeClearTypeString).toBe('');
+  expect(diff.afterClearTypeString).toBe('');
+});

--- a/test/common/ScoreList/ScoreList.test.js
+++ b/test/common/ScoreList/ScoreList.test.js
@@ -1,0 +1,93 @@
+import { ScoreList } from '../../../src/static/common/ScoreList.js';
+import { ScoreData } from '../../../src/static/common/ScoreData.js';
+import { ScoreDetail } from '../../../src/static/common/ScoreDetail.js';
+import { Constants } from '../../../src/static/common/Constants.js';
+
+function makeScoreData(musicId, difficultyValue, score) {
+  const scoreData = new ScoreData(musicId);
+  scoreData.musicType = Constants.MUSIC_TYPE.NORMAL;
+  const detail = ScoreDetail.createFromStorage({ score });
+  scoreData.applyScoreDetail(difficultyValue, detail);
+  return scoreData;
+}
+
+test('ScoreList starts empty', () => {
+  const scoreList = new ScoreList();
+  expect(scoreList.musicIds).toHaveLength(0);
+});
+
+test('ScoreList.hasMusic returns false for missing musicId', () => {
+  const scoreList = new ScoreList();
+  expect(scoreList.hasMusic('music001')).toBe(false);
+});
+
+test('ScoreList.applyScoreData adds new ScoreData and returns diffs', () => {
+  const scoreList = new ScoreList();
+  const scoreData = makeScoreData('music001', 3, 900000);
+  const diffs = scoreList.applyScoreData(scoreData);
+  expect(scoreList.hasMusic('music001')).toBe(true);
+  expect(diffs).toHaveLength(1);
+});
+
+test('ScoreList.applyScoreData merges existing ScoreData', () => {
+  const scoreList = new ScoreList();
+  const scoreData1 = makeScoreData('music001', 3, 900000);
+  scoreList.applyScoreData(scoreData1);
+  const scoreData2 = makeScoreData('music001', 3, 950000);
+  const diffs = scoreList.applyScoreData(scoreData2);
+  expect(scoreList.getScoreDataByMusicId('music001').getScoreDetailByDifficulty(3).score).toBe(950000);
+  expect(diffs.length).toBeGreaterThan(0);
+});
+
+test('ScoreList.applyObject adds new ScoreData via storage object', () => {
+  const scoreList = new ScoreList();
+  const object = {
+    musicId: 'music001',
+    musicType: Constants.MUSIC_TYPE.NORMAL,
+    difficulty: {
+      3: { score: 900000 },
+    },
+  };
+  const diffs = scoreList.applyObject(object);
+  expect(scoreList.hasMusic('music001')).toBe(true);
+  expect(diffs).toHaveLength(1);
+});
+
+test('ScoreList.getScoreDataByMusicId returns correct ScoreData', () => {
+  const scoreList = new ScoreList();
+  const scoreData = makeScoreData('music001', 3, 900000);
+  scoreList.applyScoreData(scoreData);
+  const retrieved = scoreList.getScoreDataByMusicId('music001');
+  expect(retrieved.musicId).toBe('music001');
+});
+
+test('ScoreList.musicIds returns all music IDs', () => {
+  const scoreList = new ScoreList();
+  scoreList.applyScoreData(makeScoreData('music001', 3, 900000));
+  scoreList.applyScoreData(makeScoreData('music002', 3, 800000));
+  expect(scoreList.musicIds).toContain('music001');
+  expect(scoreList.musicIds).toContain('music002');
+  expect(scoreList.musicIds).toHaveLength(2);
+});
+
+test('ScoreList.toStorageData returns musics object', () => {
+  const scoreList = new ScoreList();
+  scoreList.applyScoreData(makeScoreData('music001', 3, 900000));
+  const storageData = scoreList.toStorageData();
+  expect(Object.prototype.hasOwnProperty.call(storageData, 'music001')).toBe(true);
+});
+
+test('ScoreList.createFromStorage restores from storage data', () => {
+  const storageData = {
+    music001: {
+      musicId: 'music001',
+      musicType: Constants.MUSIC_TYPE.NORMAL,
+      difficulty: {
+        3: { score: 900000 },
+      },
+    },
+  };
+  const scoreList = ScoreList.createFromStorage(storageData);
+  expect(scoreList.hasMusic('music001')).toBe(true);
+  expect(scoreList.getScoreDataByMusicId('music001').getScoreDetailByDifficulty(3).score).toBe(900000);
+});

--- a/test/common/SkillAttackDataElement/SkillAttackDataElement.test.js
+++ b/test/common/SkillAttackDataElement/SkillAttackDataElement.test.js
@@ -1,0 +1,104 @@
+jest.mock('../../../src/static/common/Logger.js', () => ({
+  Logger: { info: jest.fn(), debug: jest.fn(), error: jest.fn(), warn: jest.fn() },
+}));
+
+import { SkillAttackDataElement } from '../../../src/static/common/SkillAttackDataElement.js';
+import { Constants } from '../../../src/static/common/Constants.js';
+
+// Sample line format: index \t playMode \t difficulty \t ? \t updatedAt \t score \t clearType \t ?
+const sampleLine = '1\t0\t3\t0\t1234567890\t900000\t0\t0';
+const sampleLineFC = '2\t1\t2\t0\t1234567891\t850000\t1\t0';
+const sampleLinePFC = '3\t0\t4\t0\t1234567892\t990000\t2\t0';
+const sampleLineMFC = '4\t0\t3\t0\t1234567893\t1000000\t3\t0';
+
+test('SkillAttackDataElement.createFromString parses valid string', () => {
+  const element = SkillAttackDataElement.createFromString(sampleLine);
+  expect(element).not.toBeNull();
+  expect(element.index).toBe(1);
+  expect(element.playMode).toBe(0);
+  expect(element.difficulty).toBe(3);
+  expect(element.updatedAt).toBe(1234567890);
+  expect(element.score).toBe(900000);
+  expect(element.clearType).toBe(0);
+});
+
+test('SkillAttackDataElement.createFromString returns null for empty string', () => {
+  expect(SkillAttackDataElement.createFromString('')).toBeNull();
+});
+
+test('SkillAttackDataElement.createFromString returns null for whitespace-only string', () => {
+  expect(SkillAttackDataElement.createFromString('   ')).toBeNull();
+});
+
+test('SkillAttackDataElement.createFromString returns null for too-short string', () => {
+  expect(SkillAttackDataElement.createFromString('1\t0\t3')).toBeNull();
+});
+
+test('SkillAttackDataElement.difficultyValue for SINGLE player', () => {
+  const element = SkillAttackDataElement.createFromString(sampleLine);
+  // playMode=0 (SINGLE), difficulty=3 => difficultyValue=3
+  expect(element.difficultyValue).toBe(3);
+});
+
+test('SkillAttackDataElement.difficultyValue for DOUBLE player', () => {
+  const element = SkillAttackDataElement.createFromString(sampleLineFC);
+  // playMode=1 (DOUBLE), difficulty=2 => difficultyValue = 2 + 4 = 6
+  expect(element.difficultyValue).toBe(6);
+});
+
+test('SkillAttackDataElement.formString with clearType=0 returns score only', () => {
+  const element = SkillAttackDataElement.createFromString(sampleLine);
+  expect(element.formString).toBe('900000');
+});
+
+test('SkillAttackDataElement.formString with clearType=1 appends *', () => {
+  const element = SkillAttackDataElement.createFromString(sampleLineFC);
+  expect(element.formString).toBe('850000*');
+});
+
+test('SkillAttackDataElement.formString with clearType=2 appends **', () => {
+  const element = SkillAttackDataElement.createFromString(sampleLinePFC);
+  expect(element.formString).toBe('990000**');
+});
+
+test('SkillAttackDataElement.formString with clearType=3 returns score only (no suffix)', () => {
+  const element = SkillAttackDataElement.createFromString(sampleLineMFC);
+  expect(element.formString).toBe('1000000');
+});
+
+test('SkillAttackDataElement.scoreString with clearType=0 returns score only', () => {
+  const element = SkillAttackDataElement.createFromString(sampleLine);
+  expect(element.scoreString).toBe((900000).toLocaleString());
+});
+
+test('SkillAttackDataElement.scoreString with clearType=1 includes FC', () => {
+  const element = SkillAttackDataElement.createFromString(sampleLineFC);
+  expect(element.scoreString).toContain('FC');
+});
+
+test('SkillAttackDataElement.merge returns false for mismatched index', () => {
+  const el1 = SkillAttackDataElement.createFromString(sampleLine);
+  const el2 = SkillAttackDataElement.createFromString('99\t0\t3\t0\t1234567891\t950000\t0\t0');
+  expect(el1.merge(el2)).toBe(false);
+});
+
+test('SkillAttackDataElement.merge updates score when other is newer', () => {
+  const el1 = SkillAttackDataElement.createFromString(sampleLine); // updatedAt=1234567890
+  const el2 = SkillAttackDataElement.createFromString('1\t0\t3\t0\t1234567999\t950000\t0\t0'); // newer
+  el1.merge(el2);
+  expect(el1.score).toBe(950000);
+  expect(el1.updatedAt).toBe(1234567999);
+});
+
+test('SkillAttackDataElement.merge does not update score when other is older', () => {
+  const el1 = SkillAttackDataElement.createFromString(sampleLine); // updatedAt=1234567890
+  const el2 = SkillAttackDataElement.createFromString('1\t0\t3\t0\t1000000000\t999999\t0\t0'); // older
+  el1.merge(el2);
+  expect(el1.score).toBe(900000);
+});
+
+test('SkillAttackDataElement.merge returns true for valid same-key elements', () => {
+  const el1 = SkillAttackDataElement.createFromString(sampleLine);
+  const el2 = SkillAttackDataElement.createFromString('1\t0\t3\t0\t1234567999\t950000\t0\t0');
+  expect(el1.merge(el2)).toBe(true);
+});

--- a/test/common/SkillAttackDataList/SkillAttackDataList.test.js
+++ b/test/common/SkillAttackDataList/SkillAttackDataList.test.js
@@ -1,0 +1,140 @@
+jest.mock('../../../src/static/common/Logger.js', () => ({
+  Logger: { info: jest.fn(), debug: jest.fn(), error: jest.fn(), warn: jest.fn() },
+}));
+
+import { SkillAttackDataList } from '../../../src/static/common/SkillAttackDataList.js';
+import { SkillAttackDataElement } from '../../../src/static/common/SkillAttackDataElement.js';
+import { SkillAttackIndexMap } from '../../../src/static/common/SkillAttackIndexMap.js';
+
+// line format: index \t playMode \t difficulty \t ? \t updatedAt \t score \t clearType \t ?
+const line1 = '1\t0\t3\t0\t1234567890\t900000\t0\t0'; // index=1, SP, ESP, score=900000
+const line2 = '2\t0\t2\t0\t1234567890\t850000\t0\t0'; // index=2, SP, DSP, score=850000
+
+test('SkillAttackDataList starts empty', () => {
+  const list = new SkillAttackDataList({});
+  expect(list.count).toBe(0);
+});
+
+test('SkillAttackDataList.applyText parses lines and populates elements', () => {
+  const list = new SkillAttackDataList({});
+  list.applyText(`${line1}\n${line2}\n`);
+  expect(list.count).toBe(2);
+});
+
+test('SkillAttackDataList.applyText ignores blank lines', () => {
+  const list = new SkillAttackDataList({});
+  list.applyText(`\n${line1}\n\n`);
+  expect(list.count).toBe(1);
+});
+
+test('SkillAttackDataList.hasIndex returns true after applyText', () => {
+  const list = new SkillAttackDataList({});
+  list.applyText(line1);
+  expect(list.hasIndex(1)).toBe(true);
+});
+
+test('SkillAttackDataList.hasIndex returns false for missing index', () => {
+  const list = new SkillAttackDataList({});
+  expect(list.hasIndex(999)).toBe(false);
+});
+
+test('SkillAttackDataList.hasElement returns true for existing element', () => {
+  const list = new SkillAttackDataList({});
+  list.applyText(line1);
+  // difficultyValue for playMode=0, difficulty=3 is 3
+  expect(list.hasElement(1, 3)).toBe(true);
+});
+
+test('SkillAttackDataList.hasElement returns false for missing difficultyValue', () => {
+  const list = new SkillAttackDataList({});
+  list.applyText(line1);
+  expect(list.hasElement(1, 4)).toBe(false);
+});
+
+test('SkillAttackDataList.getElement returns element for existing key', () => {
+  const list = new SkillAttackDataList({});
+  list.applyText(line1);
+  const el = list.getElement(1, 3);
+  expect(el).not.toBeNull();
+  expect(el.score).toBe(900000);
+});
+
+test('SkillAttackDataList.getElement returns null for missing element', () => {
+  const list = new SkillAttackDataList({});
+  expect(list.getElement(999, 3)).toBeNull();
+});
+
+test('SkillAttackDataList.applyElement merges when element already exists', () => {
+  const list = new SkillAttackDataList({});
+  list.applyText(line1);
+  // Apply newer element with higher score
+  const newer = SkillAttackDataElement.createFromString('1\t0\t3\t0\t9999999999\t950000\t0\t0');
+  list.applyElement(newer);
+  expect(list.getElement(1, 3).score).toBe(950000);
+});
+
+test('SkillAttackDataList.applyElement does nothing with null', () => {
+  const list = new SkillAttackDataList({});
+  list.applyElement(null);
+  expect(list.count).toBe(0);
+});
+
+test('SkillAttackDataList.urlSearchParams produces correct params', () => {
+  const list = new SkillAttackDataList({});
+  list.applyText(line1);
+  const params = list.urlSearchParams('1234567890', 'password');
+  expect(params.get('_')).toBe('score_submit');
+  expect(params.get('password')).toBe('password');
+  expect(params.get('ddrcode')).toBe('1234567890');
+  // 'index[]' should contain index 1
+  expect(params.getAll('index[]')).toContain('1');
+});
+
+test('SkillAttackDataList.getDiff returns elements with higher score', () => {
+  const indexMapText = '1\tmusic001\n';
+  const indexMap = SkillAttackIndexMap.createFromText(indexMapText);
+
+  // Existing SA data: score=800000
+  const existingList = new SkillAttackDataList(indexMap);
+  existingList.applyText('1\t0\t3\t0\t1234567890\t800000\t0\t0');
+
+  // Create mock musicList and scoreList
+  const musicList = {
+    hasMusic: () => false,
+    getMusicDataById: () => null,
+  };
+  const scoreList = {
+    musicIds: ['music001'],
+    getScoreDataByMusicId: () => ({
+      difficulties: ['3'],
+      getScoreDetailByDifficulty: () => ({ score: 900000, clearType: 0 }),
+    }),
+  };
+
+  const diff = existingList.getDiff(musicList, scoreList);
+  expect(diff.count).toBe(1);
+});
+
+test('SkillAttackDataList.getDiff does not include when score is not higher', () => {
+  const indexMapText = '1\tmusic001\n';
+  const indexMap = SkillAttackIndexMap.createFromText(indexMapText);
+
+  // Existing SA data: score=900000
+  const existingList = new SkillAttackDataList(indexMap);
+  existingList.applyText('1\t0\t3\t0\t1234567890\t900000\t0\t0');
+
+  const musicList = {
+    hasMusic: () => false,
+    getMusicDataById: () => null,
+  };
+  const scoreList = {
+    musicIds: ['music001'],
+    getScoreDataByMusicId: () => ({
+      difficulties: ['3'],
+      getScoreDetailByDifficulty: () => ({ score: 900000, clearType: 0 }),
+    }),
+  };
+
+  const diff = existingList.getDiff(musicList, scoreList);
+  expect(diff.count).toBe(0);
+});

--- a/test/common/SkillAttackIndexMap/SkillAttackIndexMap.test.js
+++ b/test/common/SkillAttackIndexMap/SkillAttackIndexMap.test.js
@@ -1,0 +1,51 @@
+jest.mock('../../../src/static/common/Logger.js', () => ({
+  Logger: { info: jest.fn(), debug: jest.fn(), error: jest.fn(), warn: jest.fn() },
+}));
+
+import { SkillAttackIndexMap } from '../../../src/static/common/SkillAttackIndexMap.js';
+
+const sampleText = '1\tabc123\n2\tdef456\n3\tghi789\n';
+
+test('SkillAttackIndexMap.createFromText parses tab-separated lines', () => {
+  const map = SkillAttackIndexMap.createFromText(sampleText);
+  expect(map.getMusicIdByIndex(1)).toBe('abc123');
+  expect(map.getMusicIdByIndex(2)).toBe('def456');
+  expect(map.getMusicIdByIndex(3)).toBe('ghi789');
+});
+
+test('SkillAttackIndexMap.createFromText ignores blank lines', () => {
+  const map = SkillAttackIndexMap.createFromText('\n1\tabc123\n\n2\tdef456\n');
+  expect(map.getMusicIdByIndex(1)).toBe('abc123');
+  expect(map.getMusicIdByIndex(2)).toBe('def456');
+});
+
+test('SkillAttackIndexMap.getIndexByMusicId returns correct index', () => {
+  const map = SkillAttackIndexMap.createFromText(sampleText);
+  expect(map.getIndexByMusicId('abc123')).toBe(1);
+  expect(map.getIndexByMusicId('def456')).toBe(2);
+});
+
+test('SkillAttackIndexMap.hasIndex returns true for existing index', () => {
+  const map = SkillAttackIndexMap.createFromText(sampleText);
+  expect(map.hasIndex(1)).toBe(true);
+});
+
+test('SkillAttackIndexMap.hasIndex returns false for missing index', () => {
+  const map = SkillAttackIndexMap.createFromText(sampleText);
+  expect(map.hasIndex(999)).toBe(false);
+});
+
+test('SkillAttackIndexMap.hasMusicId returns true for existing musicId', () => {
+  const map = SkillAttackIndexMap.createFromText(sampleText);
+  expect(map.hasMusicId('abc123')).toBe(true);
+});
+
+test('SkillAttackIndexMap.hasMusicId returns false for missing musicId', () => {
+  const map = SkillAttackIndexMap.createFromText(sampleText);
+  expect(map.hasMusicId('notexist')).toBe(false);
+});
+
+test('SkillAttackIndexMap.createFromText with empty string creates empty map', () => {
+  const map = SkillAttackIndexMap.createFromText('');
+  expect(map.hasIndex(1)).toBe(false);
+});


### PR DESCRIPTION
Closes #561

現在のコードの振る舞いを正として、未テストの関数・コードパスにテストを追加しました。21ファイル、11クラスを対象。

Generated with [Claude Code](https://claude.ai/code)