### PR TITLE
feat: TypeScript化 - SkillAttack + Parser (PR5 of #571)

### DIFF
--- a/src/static/common/Parser.ts
+++ b/src/static/common/Parser.ts
@@ -1,7 +1,37 @@
 import { MusicData } from './MusicData.js';
 import { ScoreData } from './ScoreData.js';
 import { ScoreDetail } from './ScoreDetail.js';
-import { Constants } from './Constants.js';
+import { Constants, type GameVersion, type MusicType, type ScoreRank, type ClearType, type FlareRank } from './Constants.js';
+
+type ParseStatus = 0 | 1 | 2;
+
+type MusicListResult = {
+  hasNext: boolean;
+  nextUrl: string;
+  currentPage: number | null;
+  maxPage: number | null;
+  musics: MusicData[];
+  status: ParseStatus;
+};
+
+type MusicDetailResult = {
+  musics: MusicData[];
+  status: ParseStatus;
+};
+
+type ScoreListResult = {
+  hasNext: boolean;
+  nextUrl: string;
+  currentPage: number | null;
+  maxPage: number | null;
+  scores: ScoreData[];
+  status: ParseStatus;
+};
+
+type ScoreDetailResult = {
+  scores: ScoreData[];
+  status: ParseStatus;
+};
 
 export class Parser {
   static get STATUS() {
@@ -12,18 +42,18 @@ export class Parser {
     };
   }
 
-  static getResultStatus(rootElement) {
+  static getResultStatus(rootElement: Element): ParseStatus {
     if (rootElement.querySelector('#login.errinfo_btn') !== null || rootElement.querySelector('#basic.errinfo_btn') !== null) {
-      return this.STATUS.LOGIN_REQUIRED;
+      return this.STATUS.LOGIN_REQUIRED as ParseStatus;
     }
     if (rootElement.querySelector('#error') !== null) {
-      return this.STATUS.UNKNOWN_ERROR;
+      return this.STATUS.UNKNOWN_ERROR as ParseStatus;
     }
-    return this.STATUS.SUCCESS;
+    return this.STATUS.SUCCESS as ParseStatus;
   }
 
-  static parseMusicList(rootElement, _gameVersion) {
-    const res = {
+  static parseMusicList(rootElement: Element, _gameVersion?: GameVersion): MusicListResult {
+    const res: MusicListResult = {
       hasNext: false,
       nextUrl: '',
       currentPage: null,
@@ -37,33 +67,33 @@ export class Parser {
     const next = rootElement.querySelectorAll('#next.arrow');
     if (next.length > 0) {
       res.hasNext = true;
-      res.nextUrl = next[0].querySelector('a').href;
+      res.nextUrl = (next[0].querySelector('a') as HTMLAnchorElement).href;
     }
 
-    res.currentPage = parseInt(rootElement.querySelector('#thispage').querySelector('a').innerHTML, 10);
+    res.currentPage = parseInt((rootElement.querySelector('#thispage') as Element).querySelector('a').innerHTML, 10);
     const pages = rootElement.querySelectorAll('#paging_box')[0].querySelectorAll('.page_num');
     res.maxPage = parseInt(pages[pages.length - 1].querySelector('a').innerHTML, 10);
 
     const musics = rootElement.querySelectorAll('tr.data');
     musics.forEach(function (music) {
       const regexp = /^.*img=([0-9a-zA-Z]+).*$/;
-      const src = music.querySelector('td img').src;
+      const src = (music.querySelector('td img') as HTMLImageElement).src;
       const musicId = src.replace(regexp, '$1');
       const title = music.querySelector('.music_tit').innerHTML;
       const difficulty = Array.from(music.querySelectorAll('.difficult')).map(function (element) {
         const value = parseInt(element.innerHTML, 10);
         return value ? value : 0;
       });
-      const musicData = new MusicData(musicId, Constants.MUSIC_TYPE.NORMAL, title, difficulty, 0);
+      const musicData = new MusicData(musicId, Constants.MUSIC_TYPE.NORMAL as MusicType, title, difficulty, 0);
       res.musics.push(musicData);
     });
-    res.status = this.STATUS.SUCCESS;
+    res.status = this.STATUS.SUCCESS as ParseStatus;
     return res;
   }
 
-  // getDifficulties: (rootElement) => number[]
-  static parseMusicDetailCore(rootElement, getDifficulties) {
-    const res = {
+  // getDifficulties: (rootElement: Element) => number[]
+  static parseMusicDetailCore(rootElement: Element, getDifficulties: (root: Element) => number[]): MusicDetailResult {
+    const res: MusicDetailResult = {
       musics: [],
       status: this.getResultStatus(rootElement),
     };
@@ -72,24 +102,24 @@ export class Parser {
     }
     const musicInfo = rootElement.querySelectorAll('#music_info td');
     if (musicInfo.length < 1) {
-      res.status = this.STATUS.UNKNOWN_ERROR;
+      res.status = this.STATUS.UNKNOWN_ERROR as ParseStatus;
       return res;
     }
     const regexpForMusicId = /^.*img=([0-9a-zA-Z]+).*$/;
-    const musicId = musicInfo[0].querySelector('img').src.replace(regexpForMusicId, '$1');
+    const musicId = (musicInfo[0].querySelector('img') as HTMLImageElement).src.replace(regexpForMusicId, '$1');
     const title = musicInfo.length > 1 ? musicInfo[1].innerHTML.split('<br>')[0] : '';
     const difficulty = getDifficulties(rootElement);
-    res.musics.push(new MusicData(musicId, Constants.MUSIC_TYPE.NORMAL, title, difficulty, 0));
-    res.status = this.STATUS.SUCCESS;
+    res.musics.push(new MusicData(musicId, Constants.MUSIC_TYPE.NORMAL as MusicType, title, difficulty, 0));
+    res.status = this.STATUS.SUCCESS as ParseStatus;
     return res;
   }
 
-  static parseMusicDetail(rootElement, gameVersion) {
+  static parseMusicDetail(rootElement: Element, gameVersion: GameVersion): MusicDetailResult {
     const regexpForDifficulties = /^.*songdetails_level_([0-9]*).png$/;
     if (gameVersion === Constants.GAME_VERSION.WORLD) {
       return this.parseMusicDetailCore(rootElement, (root) => {
         return Array.from(root.querySelectorAll('li.step')).map((element) => {
-          const img = element.querySelector('img');
+          const img = element.querySelector('img') as HTMLImageElement | null;
           if (img === null) {
             return 0;
           }
@@ -100,15 +130,15 @@ export class Parser {
     }
     return this.parseMusicDetailCore(rootElement, (root) => {
       return Array.from(root.querySelectorAll('li.step img')).map((element) => {
-        const value = parseInt(element.src.replace(regexpForDifficulties, '$1'), 10);
+        const value = parseInt((element as HTMLImageElement).src.replace(regexpForDifficulties, '$1'), 10);
         return value ? value : 0;
       });
     });
   }
 
-  // buildScoreDetail: (detailElement) => ScoreDetail | null (null means NO_PLAY, skip)
-  static parseScoreListCore(rootElement, buildScoreDetail) {
-    const res = {
+  // buildScoreDetail: (detailElement: Element) => ScoreDetail | null (null means NO_PLAY, skip)
+  static parseScoreListCore(rootElement: Element, buildScoreDetail: (detail: Element) => ScoreDetail | null): ScoreListResult {
+    const res: ScoreListResult = {
       hasNext: false,
       nextUrl: '',
       currentPage: null,
@@ -122,10 +152,10 @@ export class Parser {
     const next = rootElement.querySelectorAll('#next.arrow');
     if (next.length > 0) {
       res.hasNext = true;
-      res.nextUrl = next[0].querySelector('a').href;
+      res.nextUrl = (next[0].querySelector('a') as HTMLAnchorElement).href;
     }
 
-    res.currentPage = parseInt(rootElement.querySelector('#thispage').querySelector('a').innerHTML, 10);
+    res.currentPage = parseInt((rootElement.querySelector('#thispage') as Element).querySelector('a').innerHTML, 10);
     const pages = rootElement.querySelectorAll('#paging_box')[0].querySelectorAll('.page_num');
     res.maxPage = parseInt(pages[pages.length - 1].querySelector('a').innerHTML, 10);
 
@@ -133,7 +163,7 @@ export class Parser {
     const scores = Array.from(rootElement.querySelectorAll('tr.data'));
     scores.forEach(function (score) {
       const regexp = /^.*img=([0-9a-zA-Z]+).*$/;
-      const musicId = score.querySelector('td img.jk, td img.jk2').src.replace(regexp, '$1');
+      const musicId = (score.querySelector('td img.jk, td img.jk2') as HTMLImageElement).src.replace(regexp, '$1');
       const scoreData = new ScoreData(musicId);
       Object.keys(Constants.DIFFICULTY_NAME_MAP).forEach(function (difficultyName) {
         const difficulty = Constants.DIFFICULTY_NAME_MAP[difficultyName] + (isDouble ? Constants.DIFFICULTIES_OFFSET_FOR_DOUBLE : 0);
@@ -147,29 +177,29 @@ export class Parser {
         if (scoreDetail === null) {
           return;
         }
-        scoreData.applyScoreDetail(difficulty, scoreDetail);
+        scoreData.applyScoreDetail(String(difficulty), scoreDetail);
       });
       res.scores.push(scoreData);
     });
-    res.status = this.STATUS.SUCCESS;
+    res.status = this.STATUS.SUCCESS as ParseStatus;
     return res;
   }
 
-  static parseScoreList(rootElement, gameVersion) {
+  static parseScoreList(rootElement: Element, gameVersion: GameVersion): ScoreListResult {
     const fileNameRegexp = /^.*\/([^/]+)$/;
     if (gameVersion === Constants.GAME_VERSION.WORLD) {
       return this.parseScoreListCore(rootElement, (detail) => {
         const scoreDetail = new ScoreDetail();
-        const scoreValue = parseInt(detail.querySelector('.data_score').innerHTML, 10);
+        const scoreValue = parseInt((detail.querySelector('.data_score') as Element).innerHTML, 10);
         scoreDetail.score = scoreValue ? scoreValue : 0;
-        const flareSkill = parseInt(detail.querySelector('.data_flareskill').innerHTML, 10);
+        const flareSkill = parseInt((detail.querySelector('.data_flareskill') as Element).innerHTML, 10);
         scoreDetail.flareSkill = flareSkill ? flareSkill : null;
-        const scoreRankFileName = detail.querySelectorAll('div.data_rank img')[0].src.replace(fileNameRegexp, '$1');
-        const clearTypeFileName = detail.querySelectorAll('div.data_clearkind img')[0].src.replace(fileNameRegexp, '$1');
-        const flareRankFileName = detail.querySelectorAll('div.data_flarerank img')[0].src.replace(fileNameRegexp, '$1');
-        scoreDetail.scoreRank = Constants.SCORE_RANK_FILE_MAP_DDRWORLD[scoreRankFileName];
-        scoreDetail.clearType = Constants.CLEAR_TYPE_FILE_MAP_DDRWORLD[clearTypeFileName];
-        scoreDetail.flareRank = Constants.FLARE_RANK_FILE_MAP_DDRWORLD[flareRankFileName];
+        const scoreRankFileName = (detail.querySelectorAll('div.data_rank img')[0] as HTMLImageElement).src.replace(fileNameRegexp, '$1');
+        const clearTypeFileName = (detail.querySelectorAll('div.data_clearkind img')[0] as HTMLImageElement).src.replace(fileNameRegexp, '$1');
+        const flareRankFileName = (detail.querySelectorAll('div.data_flarerank img')[0] as HTMLImageElement).src.replace(fileNameRegexp, '$1');
+        scoreDetail.scoreRank = Constants.SCORE_RANK_FILE_MAP_DDRWORLD[scoreRankFileName] as ScoreRank;
+        scoreDetail.clearType = Constants.CLEAR_TYPE_FILE_MAP_DDRWORLD[clearTypeFileName] as ClearType;
+        scoreDetail.flareRank = Constants.FLARE_RANK_FILE_MAP_DDRWORLD[flareRankFileName] as FlareRank;
         if (scoreDetail.scoreRank === Constants.SCORE_RANK.NO_PLAY) {
           return null;
         }
@@ -178,12 +208,12 @@ export class Parser {
     }
     return this.parseScoreListCore(rootElement, (detail) => {
       const scoreDetail = new ScoreDetail();
-      const value = parseInt(detail.querySelector('.data_score').innerHTML, 10);
+      const value = parseInt((detail.querySelector('.data_score') as Element).innerHTML, 10);
       scoreDetail.score = value ? value : 0;
-      const scoreRankFileName = detail.querySelectorAll('div.data_rank img')[0].src.replace(fileNameRegexp, '$1');
-      const clearTypeFileName = detail.querySelectorAll('div.data_rank img')[1].src.replace(fileNameRegexp, '$1');
-      scoreDetail.scoreRank = Constants.SCORE_RANK_FILE_MAP[scoreRankFileName];
-      scoreDetail.clearType = Constants.CLEAR_TYPE_FILE_MAP[clearTypeFileName];
+      const scoreRankFileName = (detail.querySelectorAll('div.data_rank img')[0] as HTMLImageElement).src.replace(fileNameRegexp, '$1');
+      const clearTypeFileName = (detail.querySelectorAll('div.data_rank img')[1] as HTMLImageElement).src.replace(fileNameRegexp, '$1');
+      scoreDetail.scoreRank = Constants.SCORE_RANK_FILE_MAP[scoreRankFileName] as ScoreRank;
+      scoreDetail.clearType = Constants.CLEAR_TYPE_FILE_MAP[clearTypeFileName] as ClearType;
       if (scoreDetail.scoreRank === Constants.SCORE_RANK.NO_PLAY) {
         return null;
       }
@@ -192,8 +222,8 @@ export class Parser {
   }
 
   // fillScoreDetail: (detail: string[], scoreDetail: ScoreDetail) => void
-  static parseScoreDetailCore(rootElement, fillScoreDetail) {
-    const res = {
+  static parseScoreDetailCore(rootElement: Element, fillScoreDetail: (detail: string[], scoreDetail: ScoreDetail) => void): ScoreDetailResult {
+    const res: ScoreDetailResult = {
       scores: [],
       status: this.getResultStatus(rootElement),
     };
@@ -204,11 +234,11 @@ export class Parser {
       return element.innerHTML;
     });
     if (detail.length > 0) {
-      const musicInfo = rootElement.querySelector('#music_info td');
+      const musicInfo = rootElement.querySelector('#music_info td') as Element;
       const regexpForMusicId = /^.*img=([0-9a-zA-Z]+).*$/;
-      const musicId = musicInfo.querySelector('img').src.replace(regexpForMusicId, '$1');
+      const musicId = (musicInfo.querySelector('img') as HTMLImageElement).src.replace(regexpForMusicId, '$1');
 
-      const params = new URL(document.location).searchParams;
+      const params = new URL(document.location.href).searchParams;
       const difficulty = params.get('diff');
 
       const scoreData = new ScoreData(musicId);
@@ -217,11 +247,11 @@ export class Parser {
       scoreData.applyScoreDetail(difficulty, scoreDetail);
       res.scores.push(scoreData);
     }
-    res.status = this.STATUS.SUCCESS;
+    res.status = this.STATUS.SUCCESS as ParseStatus;
     return res;
   }
 
-  static parseScoreDetail(rootElement, gameVersion) {
+  static parseScoreDetail(rootElement: Element, gameVersion: GameVersion): ScoreDetailResult {
     if (gameVersion === Constants.GAME_VERSION.WORLD) {
       return this.parseScoreDetailCore(rootElement, (detail, scoreDetail) => {
         scoreDetail.playCount = parseInt(detail[6], 10) ? parseInt(detail[6], 10) : 0;
@@ -231,8 +261,8 @@ export class Parser {
     }
     return this.parseScoreDetailCore(rootElement, (detail, scoreDetail) => {
       scoreDetail.score = parseInt(detail[2], 10) ? parseInt(detail[2], 10) : 0;
-      scoreDetail.scoreRank = Constants.SCORE_RANK_NAME_MAP[detail[1]];
-      scoreDetail.clearType = Constants.CLEAR_TYPE_NAME_MAP[detail[7]];
+      scoreDetail.scoreRank = Constants.SCORE_RANK_NAME_MAP[detail[1]] as ScoreRank;
+      scoreDetail.clearType = Constants.CLEAR_TYPE_NAME_MAP[detail[7]] as ClearType;
       scoreDetail.playCount = parseInt(detail[4], 10) ? parseInt(detail[4], 10) : 0;
       scoreDetail.clearCount = parseInt(detail[8], 10) ? parseInt(detail[8], 10) : 0;
       scoreDetail.maxCombo = parseInt(detail[3], 10) ? parseInt(detail[3], 10) : 0;

--- a/src/static/common/SkillAttackDataElement.ts
+++ b/src/static/common/SkillAttackDataElement.ts
@@ -1,8 +1,15 @@
-import { Constants } from './Constants.js';
+import { Constants, type PlayMode, type Difficulty, type DifficultyValue } from './Constants.js';
 import { Logger } from './Logger.js';
 
 export class SkillAttackDataElement {
-  get clearTypeString() {
+  index: number;
+  playMode: PlayMode;
+  difficulty: Difficulty;
+  updatedAt: number;
+  score: number;
+  clearType: number;
+
+  get clearTypeString(): Record<number, string> {
     return {
       0: '',
       1: 'FC',
@@ -11,7 +18,7 @@ export class SkillAttackDataElement {
     };
   }
 
-  get scoreString() {
+  get scoreString(): string {
     let string = this.score.toLocaleString();
     if (this.clearType !== 0) {
       string = string + ' ' + this.clearTypeString[this.clearType];
@@ -19,7 +26,7 @@ export class SkillAttackDataElement {
     return string;
   }
 
-  constructor(index, playMode, difficulty, updatedAt, score, clearType) {
+  constructor(index: number, playMode: PlayMode, difficulty: Difficulty, updatedAt: number, score: number, clearType: number) {
     this.index = index;
     this.playMode = playMode;
     this.difficulty = difficulty;
@@ -28,7 +35,7 @@ export class SkillAttackDataElement {
     this.clearType = clearType;
   }
 
-  static createFromString(encodedString) {
+  static createFromString(encodedString: string): SkillAttackDataElement | null {
     if (encodedString.trim() === '') {
       return null;
     }
@@ -39,19 +46,19 @@ export class SkillAttackDataElement {
     }
     return new SkillAttackDataElement(
       parseInt(elements[0], 10), // index
-      parseInt(elements[1], 10), // playMode
-      parseInt(elements[2], 10), // difficulty
+      parseInt(elements[1], 10) as PlayMode, // playMode
+      parseInt(elements[2], 10) as Difficulty, // difficulty
       parseInt(elements[4], 10), // updatedAt
       parseInt(elements[5], 10), // score
       parseInt(elements[6], 10) // clearType
     );
   }
 
-  get difficultyValue() {
-    return Number(this.difficulty) + (this.playMode === Constants.PLAY_MODE.DOUBLE ? Constants.DIFFICULTIES_OFFSET_FOR_DOUBLE : 0);
+  get difficultyValue(): DifficultyValue {
+    return (Number(this.difficulty) + (this.playMode === Constants.PLAY_MODE.DOUBLE ? Constants.DIFFICULTIES_OFFSET_FOR_DOUBLE : 0)) as DifficultyValue;
   }
 
-  get formString() {
+  get formString(): string {
     switch (this.clearType) {
       case 1:
         return `${this.score}*`;
@@ -61,7 +68,7 @@ export class SkillAttackDataElement {
     return `${this.score}`;
   }
 
-  merge(skillAttackDataElement) {
+  merge(skillAttackDataElement: SkillAttackDataElement): boolean {
     if (this.index !== skillAttackDataElement.index || this.playMode !== skillAttackDataElement.playMode || this.difficulty !== skillAttackDataElement.difficulty) {
       return false;
     }

--- a/src/static/common/SkillAttackDataList.ts
+++ b/src/static/common/SkillAttackDataList.ts
@@ -1,15 +1,21 @@
 import { SkillAttackDataElement } from './SkillAttackDataElement.js';
+import { SkillAttackIndexMap } from './SkillAttackIndexMap.js';
 import { Constants } from './Constants.js';
 import { Logger } from './Logger.js';
 import { Util } from './Util.js';
+import { MusicList } from './MusicList.js';
+import { ScoreList } from './ScoreList.js';
 
 export class SkillAttackDataList {
-  constructor(skillAttackIndexMap) {
+  elements: Record<number, Record<number, SkillAttackDataElement>>;
+  skillAttackIndexMap: SkillAttackIndexMap;
+
+  constructor(skillAttackIndexMap: SkillAttackIndexMap) {
     this.elements = {};
     this.skillAttackIndexMap = skillAttackIndexMap;
   }
 
-  applyText(text) {
+  applyText(text: string): void {
     const lines = text.split('\n');
     Logger.debug(`SkillAttackDataList.createFromText: text contains ${lines.length} elements.`);
     lines.forEach((line) => {
@@ -21,14 +27,14 @@ export class SkillAttackDataList {
     });
   }
 
-  hasIndex(index) {
+  hasIndex(index: number): boolean {
     if (Object.prototype.hasOwnProperty.call(this.elements, index)) {
       return true;
     }
     return false;
   }
 
-  hasElement(index, difficultyValue) {
+  hasElement(index: number, difficultyValue: number): boolean {
     if (Object.prototype.hasOwnProperty.call(this.elements, index)) {
       if (Object.prototype.hasOwnProperty.call(this.elements[index], difficultyValue)) {
         return true;
@@ -37,14 +43,14 @@ export class SkillAttackDataList {
     return false;
   }
 
-  getElement(index, difficultyValue) {
+  getElement(index: number, difficultyValue: number): SkillAttackDataElement | null {
     if (this.hasElement(index, difficultyValue)) {
       return this.elements[index][difficultyValue];
     }
     return null;
   }
 
-  applyElement(element) {
+  applyElement(element: SkillAttackDataElement | null): boolean {
     if (element === null) {
       return false;
     }
@@ -57,9 +63,10 @@ export class SkillAttackDataList {
       }
       this.elements[element.index][element.difficultyValue] = element;
     }
+    return true;
   }
 
-  getDiff(musicList, scoreList) {
+  getDiff(musicList: MusicList, scoreList: ScoreList): SkillAttackDataList {
     const diff = new SkillAttackDataList(this.skillAttackIndexMap);
     scoreList.musicIds.forEach((musicId) => {
       const scoreData = scoreList.getScoreDataByMusicId(musicId);
@@ -69,15 +76,15 @@ export class SkillAttackDataList {
       }
       scoreData.difficulties.forEach((difficultyValue) => {
         const scoreDetail = scoreData.getScoreDetailByDifficulty(difficultyValue);
-        const currentData = this.getElement(index, difficultyValue);
+        const currentData = this.getElement(index, Number(difficultyValue));
         const score = scoreDetail.score;
         const clearType = scoreDetail.clearType > 5 ? scoreDetail.clearType - 5 : scoreDetail.clearType === 5 ? 1 : 0;
         const musicTitle = musicList.hasMusic(musicId) ? musicList.getMusicDataById(musicId).title : '???';
-        const difficultyString = Constants.PLAY_MODE_AND_DIFFICULTY_STRING[difficultyValue];
-        const data = new SkillAttackDataElement(index, Util.getPlayMode(difficultyValue), Util.getDifficulty(difficultyValue), 0, score, clearType);
+        const difficultyString = Constants.PLAY_MODE_AND_DIFFICULTY_STRING[Number(difficultyValue)];
+        const data = new SkillAttackDataElement(index, Util.getPlayMode(Number(difficultyValue) as import('./Constants.js').DifficultyValue), Util.getDifficulty(Number(difficultyValue) as import('./Constants.js').DifficultyValue), 0, score as number, clearType as number);
         if (currentData !== null) {
           // 更新チェック
-          if (score > currentData.score || clearType > currentData.clearType) {
+          if ((score as number) > currentData.score || (clearType as number) > currentData.clearType) {
             Logger.info(`${musicTitle} (${difficultyString}) : ${currentData.scoreString} → ${data.scoreString}`);
             diff.applyElement(data);
           }
@@ -91,7 +98,7 @@ export class SkillAttackDataList {
     return diff;
   }
 
-  urlSearchParams(ddrcode, password) {
+  urlSearchParams(ddrcode: string, password: string): URLSearchParams {
     const difficultyNames = ['gsp', 'bsp', 'dsp', 'esp', 'csp', 'bdp', 'ddp', 'edp', 'cdp'];
     const params = new URLSearchParams();
     params.append('_', 'score_submit');
@@ -100,7 +107,7 @@ export class SkillAttackDataList {
     Object.getOwnPropertyNames(this.elements).forEach((index) => {
       params.append('index[]', `${index}`);
       for (let difficultyValue = 0; difficultyValue < difficultyNames.length; difficultyValue++) {
-        const element = this.getElement(index, difficultyValue);
+        const element = this.getElement(Number(index), difficultyValue);
         if (element !== null) {
           params.append(`${difficultyNames[difficultyValue]}[]`, element.formString);
         } else {
@@ -111,7 +118,7 @@ export class SkillAttackDataList {
     return params;
   }
 
-  get count() {
+  get count(): number {
     return Object.getOwnPropertyNames(this.elements).length;
   }
 }

--- a/src/static/common/SkillAttackExporter.ts
+++ b/src/static/common/SkillAttackExporter.ts
@@ -2,15 +2,25 @@ import { SkillAttackIndexMap } from './SkillAttackIndexMap.js';
 import { SkillAttackDataList } from './SkillAttackDataList.js';
 import { Logger } from './Logger.js';
 import { I18n } from './I18n.js';
+import { MusicList } from './MusicList.js';
+import { ScoreList } from './ScoreList.js';
+
+type SkillAttackExporterOptions = {
+  notSendDataToSkillAttack?: boolean;
+};
 
 export class SkillAttackExporter {
-  constructor(musicList, scoreList, options) {
+  musicList: MusicList;
+  scoreList: ScoreList;
+  options: SkillAttackExporterOptions;
+
+  constructor(musicList: MusicList, scoreList: ScoreList, options: SkillAttackExporterOptions) {
     this.musicList = musicList;
     this.scoreList = scoreList;
     this.options = options;
   }
 
-  async export(ddrcode, password) {
+  async export(ddrcode: string, password: string): Promise<void> {
     const params = new URLSearchParams();
     params.append('_', '');
     params.append('password', password);

--- a/src/static/common/SkillAttackIndexMap.ts
+++ b/src/static/common/SkillAttackIndexMap.ts
@@ -1,12 +1,15 @@
 import { Logger } from './Logger.js';
 
 export class SkillAttackIndexMap {
+  indexToMusicIdMap: Record<number, string>;
+  musicIdToIndexMap: Record<string, number>;
+
   constructor() {
     this.indexToMusicIdMap = {};
     this.musicIdToIndexMap = {};
   }
 
-  static createFromText(text) {
+  static createFromText(text: string): SkillAttackIndexMap {
     const instance = new SkillAttackIndexMap();
     const lines = text.split('\n');
     Logger.debug(`SkillAttackIndexMap.createFromText: text contains ${lines.length} elements.`);
@@ -23,19 +26,19 @@ export class SkillAttackIndexMap {
     return instance;
   }
 
-  hasIndex(index) {
+  hasIndex(index: number): boolean {
     return Object.prototype.hasOwnProperty.call(this.indexToMusicIdMap, index);
   }
 
-  hasMusicId(musicId) {
+  hasMusicId(musicId: string): boolean {
     return Object.prototype.hasOwnProperty.call(this.musicIdToIndexMap, musicId);
   }
 
-  getMusicIdByIndex(index) {
+  getMusicIdByIndex(index: number): string {
     return this.indexToMusicIdMap[index];
   }
 
-  getIndexByMusicId(musicId) {
+  getIndexByMusicId(musicId: string): number {
     return this.musicIdToIndexMap[musicId];
   }
 }


### PR DESCRIPTION
## 概要

`Parser`, `SkillAttackDataElement`, `SkillAttackDataList`, `SkillAttackExporter`, `SkillAttackIndexMap` を TypeScript に変換し、DOM API 型とドメイン型を活用した型アノテーションを追加する。

## 変更内容

- `Parser.js` → `.ts`: `ParseStatus`, `MusicListResult`, `MusicDetailResult`, `ScoreListResult`, `ScoreDetailResult` 型を定義。DOM API に型アノテーション追加
- `SkillAttackIndexMap.js` → `.ts`: `Record<number, string>` 等の型を追加
- `SkillAttackDataElement.js` → `.ts`: `PlayMode`, `Difficulty`, `DifficultyValue` 型を使用
- `SkillAttackDataList.js` → `.ts`: `MusicList`, `ScoreList` を型として使用
- `SkillAttackExporter.js` → `.ts`: `SkillAttackExporterOptions` 型を定義

Related to #571 (PR5)

Generated with [Claude Code](https://claude.ai/code)