### PR TITLE
fix: options_ui のストレージ読み書きが機能しない問題を修正

### DIFF
--- a/src/options_ui/index.js
+++ b/src/options_ui/index.js
@@ -1,5 +1,4 @@
-import { App } from '../common/App.js';
-import { STATE } from '../common/AppState.js';
+import { App } from '../static/common/App.js';
 const app = new App();
 
 function saveOptions() {
@@ -36,14 +35,7 @@ function onInitialized() {
   document.getElementById('options_openDebugPage').href = `chrome-extension://${extension_id}/browser_action/debug/index.html`;
 }
 
-function initialize() {
-  if (app.getState() === STATE.INITIALIZE) {
-    setTimeout(initialize, 100);
-  } else {
-    onInitialized();
-  }
-}
-
-(function () {
-  initialize();
-})();
+window.addEventListener('load', async () => {
+  await app.init();
+  onInitialized();
+});

--- a/src/static/options_ui/index.html
+++ b/src/static/options_ui/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="utf-8" />
     <title>DDR Score Tracker</title>
-    <script src="index.js" type="module" defer></script>
+    <script src="index.js" defer></script>
     <script src="../common/i18n4html.js" type="module" defer></script>
   </head>
   <body>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,7 @@ const config = {
     "browser_action/index": './browser_action/index.js',
     "browser_action/editFilter": './browser_action/editFilter.js',
     "browser_action/debug/index": './browser_action/debug/index.js',
+    "options_ui/index": './options_ui/index.js',
   },
 
   module: {


### PR DESCRIPTION
Fixes #579

## 変更概要

- options_ui/index.js を webpack エントリとして再作成し、app.init() を呼び出すよう修正
- webpack.config.js に options_ui/index エントリを追加
- index.html から type="module" を削除

Generated with [Claude Code](https://claude.ai/code)