### PR TITLE
remove server data collection for unregistered music

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -30,5 +30,5 @@
 
   "permissions": ["tabs", "storage", "unlimitedStorage"],
 
-  "host_permissions": ["http://skillattack.com/", "https://us-west1-blissful-mile-450603-h9.cloudfunctions.net/"]
+  "host_permissions": ["http://skillattack.com/"]
 }

--- a/src/static/common/DataFetchController.ts
+++ b/src/static/common/DataFetchController.ts
@@ -115,22 +115,7 @@ export class DataFetchController {
       res.musics!.forEach((music) => {
         music['type'] = this.targetMusic!.type;
         const musicData = MusicData.createFromStorage(music);
-        const body = JSON.stringify({ text: musicData.encodedString });
-        if (this.musicList.applyMusicData(musicData)) {
-          fetch('https://us-west1-blissful-mile-450603-h9.cloudfunctions.net/unregistered_music', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            body: body,
-          })
-            .then((response) => {
-              Logger.debug(response);
-            })
-            .catch((reason) => {
-              Logger.debug(reason);
-            });
-        }
+        this.musicList.applyMusicData(musicData);
       });
       this.onSaveStorage();
       this.onUpdateCharts();

--- a/test/common/DataFetchController/DataFetchController.test.js
+++ b/test/common/DataFetchController/DataFetchController.test.js
@@ -113,7 +113,6 @@ describe('DataFetchController.handleMusicDetailResponse', () => {
   });
 
   test('成功時に曲データを適用してストレージを保存する', async () => {
-    global.fetch = jest.fn();
     const { controller, musicList, callbacks } = makeController();
     controller.targetMusic = { type: 1 };
     controller.targetMusics = [];
@@ -129,7 +128,6 @@ describe('DataFetchController.handleMusicDetailResponse', () => {
   });
 
   test('targetMusics が残っている場合は次の曲へ遷移する', async () => {
-    global.fetch = jest.fn();
     const { controller, callbacks } = makeController();
     controller.targetMusic = { type: 1 };
     controller.targetMusics = [{ musicId: '2', url: 'http://music2' }];


### PR DESCRIPTION
## Summary
- `DataFetchController.handleMusicDetailResponse()` 内の Cloud Functions へのPOST送信処理を削除
- `manifest.json` の `host_permissions` から Cloud Functions のURLを削除
- テストの不要な `global.fetch = jest.fn()` モックを削除

## Background
「不足している楽曲の情報を取得」機能で新規楽曲を検出した際、`https://us-west1-blissful-mile-450603-h9.cloudfunctions.net/unregistered_music` にデータを送信してサーバ側で収集する機能があった。bemaniwikiとライバル機能から楽曲情報を収集する仕組みが整ったため、このサーバ送信機能は不要となった。

## Test plan
- [x] `yarn test` — 全539テストがパス
- [x] `yarn build:dev` でビルドが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)