### PR TITLE
docs: README にセットアップ手順の変更点を追記 (Yarn Berry / corepack)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,16 @@ https://chromewebstore.google.com/detail/ddr-score-tracker/kecflehdfdgjkmfbhhhjd
 
 #### Build from source / ソースコードからビルド
 
+This project uses Yarn Berry (v4). [Corepack](https://nodejs.org/api/corepack.html) (bundled with Node.js 16.9+) is required to activate it automatically.
+
+本プロジェクトは Yarn Berry (v4) を使用しています。自動的に有効化するには [Corepack](https://nodejs.org/api/corepack.html)（Node.js 16.9 以降に同梱）が必要です。
+
+> **Note / 注意**: If you have Yarn Classic installed via `npm i -g yarn`, remove it first to avoid conflicts. / `npm i -g yarn` でインストールした Yarn Classic が PATH にある場合は、競合を避けるため先にアンインストールしてください。
+
 ```
 $ git clone git@github.com:ryowatanabe/DDRScoreTracker
 $ cd DDRScoreTracker
+$ corepack enable
 $ yarn
 $ yarn build
 ```
@@ -112,6 +119,10 @@ This software retrieves music list from [github pages](https://ryowatanabe.githu
 
 ## For Developers / 開発者向け
 
+Run `corepack enable` once before the first `yarn install` if you haven't already.
+
+初回の `yarn install` の前に、一度 `corepack enable` を実行してください（未実施の場合）。
+
 ```
 # apply prettier and correct files
 yarn prettier:write
@@ -122,6 +133,10 @@ yarn lint
 # run the test
 yarn test
 ```
+
+> **Supply chain protection / サプライチェーン保護**: This project enforces `npmMinimalAgeGate: 14d` — packages released within the last 14 days cannot be installed. If you urgently need a package not yet 14 days old (e.g. a CVE fix), add a pinned entry to `npmPreapprovedPackages` in `.yarnrc.yml` and remove it after the cooldown period.
+>
+> このプロジェクトでは `npmMinimalAgeGate: 14d` を設定しており、リリースから 14 日未満のパッケージはインストールできません。緊急の CVE 修正など 14 日を待てない場合は、`.yarnrc.yml` の `npmPreapprovedPackages` にバージョン固定で例外を追加し、期間経過後に削除してください。
 
 ## Internal Specifications / 内部仕様
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ This project uses Yarn Berry (v4). [Corepack](https://nodejs.org/api/corepack.ht
 
 本プロジェクトは Yarn Berry (v4) を使用しています。自動的に有効化するには [Corepack](https://nodejs.org/api/corepack.html)（Node.js 16.9 以降に同梱）が必要です。
 
-> **Note / 注意**: If you have Yarn Classic installed via `npm i -g yarn`, remove it first to avoid conflicts. / `npm i -g yarn` でインストールした Yarn Classic が PATH にある場合は、競合を避けるため先にアンインストールしてください。
+> **Note**: If you have Yarn Classic installed via `npm i -g yarn`, remove it first to avoid conflicts.
+>
+> **注意**: `npm i -g yarn` でインストールした Yarn Classic が PATH にある場合は、競合を避けるため先にアンインストールしてください。
 
 ```
 $ git clone git@github.com:ryowatanabe/DDRScoreTracker
@@ -134,9 +136,9 @@ yarn lint
 yarn test
 ```
 
-> **Supply chain protection / サプライチェーン保護**: This project enforces `npmMinimalAgeGate: 14d` — packages released within the last 14 days cannot be installed. If you urgently need a package not yet 14 days old (e.g. a CVE fix), add a pinned entry to `npmPreapprovedPackages` in `.yarnrc.yml` and remove it after the cooldown period.
+> **Supply chain protection**: This project enforces `npmMinimalAgeGate: 14d` — packages released within the last 14 days cannot be installed. If you urgently need a package not yet 14 days old (e.g. a CVE fix), add a pinned entry to `npmPreapprovedPackages` in `.yarnrc.yml` and remove it after the cooldown period.
 >
-> このプロジェクトでは `npmMinimalAgeGate: 14d` を設定しており、リリースから 14 日未満のパッケージはインストールできません。緊急の CVE 修正など 14 日を待てない場合は、`.yarnrc.yml` の `npmPreapprovedPackages` にバージョン固定で例外を追加し、期間経過後に削除してください。
+> **サプライチェーン保護**: このプロジェクトでは `npmMinimalAgeGate: 14d` を設定しており、リリースから 14 日未満のパッケージはインストールできません。緊急の CVE 修正など 14 日を待てない場合は、`.yarnrc.yml` の `npmPreapprovedPackages` にバージョン固定で例外を追加し、期間経過後に削除してください。
 
 ## Internal Specifications / 内部仕様
 


### PR DESCRIPTION
## Summary

PR #650 (Yarn Berry 移行) に伴い、README のセットアップ手順を更新。

- **Build from source** セクションに `corepack enable` を追加
- Yarn Classic (`npm i -g yarn`) との競合に関する注意書きを追記
- **For Developers** セクションに `npmMinimalAgeGate: 14d` の運用説明（緊急時の `npmPreapprovedPackages` 運用）を追記

## Test plan

- [ ] README のレンダリングを GitHub 上で確認（コードブロック・注記が正しく表示される）

🤖 Generated with [Claude Code](https://claude.com/claude-code)