### PR TITLE
feat: スコアリスト画面にレスポンシブ2ペインレイアウトを導入

### DIFF
--- a/src/browser_action/filter.ts
+++ b/src/browser_action/filter.ts
@@ -92,6 +92,17 @@ export function initialize(a: App) {
   applyConditions(conditions);
 
   refreshList();
+
+  /* 2ペインの閾値をまたぐ瞬間だけ transition を一時停止してドロワーアニメーションを抑制する */
+  const filterEl = document.getElementById('filterContainer')!;
+  window.matchMedia('(min-width: 1024px)').addEventListener('change', () => {
+    filterEl.classList.replace('initialized', 'not-initialized');
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        filterEl.classList.replace('not-initialized', 'initialized');
+      });
+    });
+  });
 }
 
 function openFilter() {

--- a/src/browser_action/filter.ts
+++ b/src/browser_action/filter.ts
@@ -93,6 +93,13 @@ export function initialize(a: App) {
 
   refreshList();
 
+  /* チェックボックス・ラジオボタンの変更で即時リスト更新 */
+  document.getElementById('filterContainer')!.addEventListener('change', (e) => {
+    if ((e.target as HTMLElement).tagName === 'INPUT') {
+      refreshList();
+    }
+  });
+
   /* 2ペインの閾値をまたぐ瞬間だけ transition を一時停止してドロワーアニメーションを抑制する */
   const filterEl = document.getElementById('filterContainer')!;
   window.matchMedia('(min-width: 1024px)').addEventListener('change', () => {
@@ -121,12 +128,14 @@ function selectAll(name: string) {
   elements.forEach((element) => {
     element.checked = true;
   });
+  refreshList();
 }
 function selectNone(name: string) {
   const elements = document.querySelectorAll(`input[name=${name}]`) as NodeListOf<HTMLInputElement>;
   elements.forEach((element) => {
     element.checked = false;
   });
+  refreshList();
 }
 function selectRange(name: string, min: number, max: number) {
   const elements = document.querySelectorAll(`input[name=${name}]`) as NodeListOf<HTMLInputElement>;
@@ -134,6 +143,7 @@ function selectRange(name: string, min: number, max: number) {
     const value = parseInt(element.value, 10);
     element.checked = value >= min && value <= max;
   });
+  refreshList();
 }
 
 function updateSavedFilterSelect(selectedValue = '') {
@@ -196,6 +206,7 @@ function applySavedFilter() {
         applyConditions(savedCondition);
       }
     });
+    refreshList();
   }
 }
 

--- a/src/static/browser_action/index.html
+++ b/src/static/browser_action/index.html
@@ -7,8 +7,13 @@
   </head>
   <body>
     <div id="contentArea">
-      <div id="openMenuButton" class="drawer-switch">&lt;&lt;Menu</div>
-      <div id="openFilterButton" class="drawer-switch">&lt;&lt;Filter</div>
+      <div id="mainPane">
+        <div id="openMenuButton" class="drawer-switch">&lt;&lt;Menu</div>
+        <div id="openFilterButton" class="drawer-switch">&lt;&lt;Filter</div>
+        <div id="log-container"></div>
+        <div id="chart-diff-list"></div>
+        <div id="chart-list"></div>
+      </div>
 
       <div id="filterBackground" class="drawer-background not-initialized"></div>
       <div id="filterContainer" class="drawer filter not-initialized">
@@ -653,10 +658,6 @@
           <a href="./debug/index.html" data-i18n-key="browser_action_menu_to_debug_page_button" data-i18n-text></a>
         </div>
       </div>
-
-      <div id="log-container"></div>
-      <div id="chart-diff-list"></div>
-      <div id="chart-list"></div>
     </div>
   </body>
 </html>

--- a/src/styles/ddr-components.css
+++ b/src/styles/ddr-components.css
@@ -322,4 +322,41 @@
   .score_list > .max_combo {
     @apply text-right font-mono text-[1.2rem];
   }
+
+  /*
+  レスポンシブ 2ペインレイアウト
+  1024px 以上: 左ペインにスコアリスト、右ペインにフィルタを常時表示
+  1280px 以上: 全体最大幅 1280px で中央寄せ
+  */
+
+  @media (min-width: 1024px) {
+    #contentArea {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 380px;
+      gap: 10px;
+      max-width: 1280px;
+      margin: 0 auto;
+      align-items: start;
+    }
+
+    #mainPane {
+      min-width: 0;
+    }
+
+    #filterContainer.drawer {
+      grid-column: 2;
+      grid-row: 1 / span 99;
+      position: sticky;
+      top: 5px;
+      transform: none;
+      translate: none;
+      width: auto;
+      max-height: calc(100vh - 10px);
+    }
+
+    #openFilterButton,
+    #filterBackground {
+      display: none;
+    }
+  }
 }

--- a/src/styles/ddr-components.css
+++ b/src/styles/ddr-components.css
@@ -345,7 +345,6 @@
 
     #filterContainer.drawer {
       grid-column: 2;
-      grid-row: 1 / span 99;
       position: sticky;
       top: 5px;
       transform: none;

--- a/src/styles/ddr-components.css
+++ b/src/styles/ddr-components.css
@@ -355,6 +355,7 @@
     }
 
     #openFilterButton,
+    #closeFilterButton,
     #filterBackground {
       display: none;
     }

--- a/src/styles/ddr-components.css
+++ b/src/styles/ddr-components.css
@@ -351,7 +351,8 @@
       transform: none;
       translate: none;
       width: auto;
-      max-height: calc(100vh - 10px);
+      max-height: none;
+      overflow: visible;
     }
 
     #openFilterButton,

--- a/src/styles/ddr-components.css
+++ b/src/styles/ddr-components.css
@@ -209,6 +209,9 @@
   .drawer {
     @apply z-10 fixed top-0 left-0 box-border w-full bg-black border border-white p-[5px] translate-x-full;
   }
+  #logContainer.drawer {
+    z-index: 20;
+  }
   .drawer.not-initialized {
     @apply transition-none;
   }
@@ -352,6 +355,7 @@
       width: auto;
       max-height: none;
       overflow: visible;
+      z-index: 1;
     }
 
     #openFilterButton,


### PR DESCRIPTION
## Summary

- ウィンドウ幅 1024px 以上でフィルタを右ペインに常時表示する 2 ペインレイアウトを実装 (`#contentArea` を CSS Grid 2 列構成に)
- 1280px 以上では全体を最大幅 1280px で中央寄せ
- `index.html` に `#mainPane` ラッパーを追加し、左列要素をひとつの grid item にまとめた
- 2 ペイン表示時のフィルタ内二重スクロールを解消 (`max-height: none; overflow: visible`)
- 2 ペイン表示時のページ下部余白を解消 (`grid-row: 1 / span 99` を削除)
- フィルタのチェックボックス・ラジオボタン変更時にスコアリストを即時更新
- 2 ペイン時はフィルタの「閉じる」ボタンと「フィルタ開くボタン」を非表示
- ウィンドウ幅が 1024px 閾値をまたぐ際のドロワーアニメーションを抑制

## Test plan

- [x] 幅 800px: ドロワー方式 (`<<Filter` ボタン + スライドイン) が正常に開閉し、フィルタ変更後に閉じるとリストが更新される
- [x] 幅 1100px: 右ペインにフィルタが常時表示、フィルタのチェックボックス変更でリストが即時更新される
- [x] 幅 1100px: ページ下部に余白が生じない、フィルタ内に独自スクロールバーが出ない
- [x] 幅 1100px: ページスクロール中、フィルタが `top: 5px` で画面追従 (sticky)
- [x] 幅 1500px: コンテンツ全体が 1280px 幅で中央寄せ
- [x] 幅 800px → 1100px への拡大時にドロワーアニメーションが走らない
- [x] `yarn test` 全件通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)