### PR TITLE
feat: フィルタ仕様を見直し

### DIFF
--- a/src/browser_action/chart-list.vue
+++ b/src/browser_action/chart-list.vue
@@ -40,19 +40,6 @@
           </div>
         </div>
       </template>
-      <template v-for="name in statistics.score.order" :key="name">
-        <template v-if="summarySettings[statistics.score[name].label]">
-          {{ getMessage('chart_list_summary_score_' + name) }}:{{ statistics.score[name].string }}
-          <div class="graph">
-            <div class="inner">
-              <span
-                :class="['element', statistics.score[name].scoreRankClassString]"
-                :style="{ width: 'calc(' + statistics.score[name].value + ' / ' + 1000000 + ' * 100%' }"
-              ></span>
-            </div>
-          </div>
-        </template>
-      </template>
       <template v-if="summarySettings.scoreStatistics">
         <template v-for="name in statistics.score.order">{{ getMessage('chart_list_summary_score_' + name) }}:{{ statistics.score[name].string }}&nbsp;</template>
       </template>

--- a/src/browser_action/filter.ts
+++ b/src/browser_action/filter.ts
@@ -178,7 +178,8 @@ function applyConditions(conditions: any) {
   });
   // check
   Object.keys(conditions.summary).forEach(function (key) {
-    (document.querySelector(`#summarySetting_${key}`) as HTMLInputElement).checked = true;
+    const element = document.querySelector(`#summarySetting_${key}`) as HTMLInputElement;
+    if (element) element.checked = true;
   });
   conditions.filter.forEach(function (condition: any) {
     condition.values.forEach(function (value: number) {

--- a/src/browser_action/filter.ts
+++ b/src/browser_action/filter.ts
@@ -76,8 +76,7 @@ export function initialize(a: App) {
   /* All, Noneのイベントハンドラをつける */
   document.getElementById('summarySetting_all')!.addEventListener('click', selectAll.bind(null, 'summarySetting'));
   document.getElementById('summarySetting_clear')!.addEventListener('click', selectNone.bind(null, 'summarySetting'));
-  filterNames.forEach((name) => {
-    document.getElementById(`filterCondition_${name}_all`)!.addEventListener('click', selectAll.bind(null, `filterCondition_${name}`));
+  filterNames.filter((name) => name !== 'playMode').forEach((name) => {
     document.getElementById(`filterCondition_${name}_clear`)!.addEventListener('click', selectNone.bind(null, `filterCondition_${name}`));
   });
   document.getElementById('filterCondition_containedVersion_classic')!.addEventListener('click', selectRange.bind(null, 'filterCondition_containedVersion', 0, 12));
@@ -196,6 +195,9 @@ function applyConditions(conditions: any) {
     (document.querySelector(`#sortCondition_attribute_${condition.attribute}`) as HTMLInputElement).checked = true;
     (document.querySelector(`#sortCondition_order_${condition.order}`) as HTMLInputElement).checked = true;
   });
+  if (!document.querySelector('input[name=filterCondition_playMode]:checked')) {
+    (document.querySelector('#filterCondition_playMode_0') as HTMLInputElement).checked = true;
+  }
 }
 
 function applySavedFilter() {

--- a/src/static/_locales/en/messages.json
+++ b/src/static/_locales/en/messages.json
@@ -47,18 +47,6 @@
   "browser_action_filter_summary_setting_score_rank": {
     "message": "Score Rank"
   },
-  "browser_action_filter_summary_setting_score_max": {
-    "message": "Max Score"
-  },
-  "browser_action_filter_summary_setting_score_min": {
-    "message": "Min Score"
-  },
-  "browser_action_filter_summary_setting_score_average": {
-    "message": "Avg Score"
-  },
-  "browser_action_filter_summary_setting_score_median": {
-    "message": "Median"
-  },
   "browser_action_filter_summary_setting_score_statistics": {
     "message": "Score Statistics"
   },

--- a/src/static/_locales/ja/messages.json
+++ b/src/static/_locales/ja/messages.json
@@ -47,18 +47,6 @@
   "browser_action_filter_summary_setting_score_rank": {
     "message": "スコアランク"
   },
-  "browser_action_filter_summary_setting_score_max": {
-    "message": "スコア最高値"
-  },
-  "browser_action_filter_summary_setting_score_min": {
-    "message": "スコア最低値"
-  },
-  "browser_action_filter_summary_setting_score_average": {
-    "message": "スコア平均値"
-  },
-  "browser_action_filter_summary_setting_score_median": {
-    "message": "スコア中央値"
-  },
   "browser_action_filter_summary_setting_score_statistics": {
     "message": "スコア統計サマリ"
   },

--- a/src/static/browser_action/index.html
+++ b/src/static/browser_action/index.html
@@ -91,20 +91,17 @@
         </div>
         <div class="condition-group">
           <span data-i18n-key="browser_action_filter_filter_condition_game_mode" data-i18n-text></span>
-          <a id="filterCondition_playMode_all">[All]</a>
-          <a id="filterCondition_playMode_clear">[Clear]</a>
           <div>
             <span class="element"
-              ><input type="checkbox" id="filterCondition_playMode_0" name="filterCondition_playMode" value="0" /><label for="filterCondition_playMode_0">SP</label></span
+              ><input type="radio" id="filterCondition_playMode_0" name="filterCondition_playMode" value="0" /><label for="filterCondition_playMode_0">SP</label></span
             >
             <span class="element"
-              ><input type="checkbox" id="filterCondition_playMode_1" name="filterCondition_playMode" value="1" /><label for="filterCondition_playMode_1">DP</label></span
+              ><input type="radio" id="filterCondition_playMode_1" name="filterCondition_playMode" value="1" /><label for="filterCondition_playMode_1">DP</label></span
             >
           </div>
         </div>
         <div class="condition-group">
           <span data-i18n-key="browser_action_filter_filter_condition_music_type" data-i18n-text></span>
-          <a id="filterCondition_musicType_all">[All]</a>
           <a id="filterCondition_musicType_clear">[Clear]</a>
           <div>
             <span class="element"
@@ -146,7 +143,6 @@
         </div>
         <div class="condition-group">
           <span data-i18n-key="browser_action_filter_filter_condition_difficulty" data-i18n-text></span>
-          <a id="filterCondition_difficulty_all">[All]</a>
           <a id="filterCondition_difficulty_clear">[Clear]</a>
           <div>
             <span class="element"
@@ -174,7 +170,6 @@
         </div>
         <div class="condition-group">
           <span data-i18n-key="browser_action_filter_filter_condition_level" data-i18n-text></span>
-          <a id="filterCondition_level_all">[All]</a>
           <a id="filterCondition_level_clear">[Clear]</a>
           <div>
             <span class="element"><input type="checkbox" id="filterCondition_level_1" name="filterCondition_level" value="1" /><label for="filterCondition_level_1">1</label></span>
@@ -220,7 +215,6 @@
         </div>
         <div class="condition-group">
           <span data-i18n-key="browser_action_filter_filter_condition_contained_version" data-i18n-text></span>
-          <a id="filterCondition_containedVersion_all">[All]</a>
           <a id="filterCondition_containedVersion_clear">[Clear]</a>
           <a id="filterCondition_containedVersion_classic">[CLASSIC]</a>
           <a id="filterCondition_containedVersion_white">[WHITE]</a>
@@ -330,7 +324,6 @@
         </div>
         <div class="condition-group">
           <span data-i18n-key="browser_action_filter_filter_condition_clear_type" data-i18n-text></span>
-          <a id="filterCondition_clearType_all">[All]</a>
           <a id="filterCondition_clearType_clear">[Clear]</a>
           <div>
             <span class="element"
@@ -366,7 +359,6 @@
         </div>
         <div class="condition-group">
           <span data-i18n-key="browser_action_filter_filter_condition_score_rank" data-i18n-text></span>
-          <a id="filterCondition_scoreRank_all">[All]</a>
           <a id="filterCondition_scoreRank_clear">[Clear]</a>
           <div>
             <span class="element"
@@ -421,7 +413,6 @@
         </div>
         <div class="condition-group">
           <span data-i18n-key="browser_action_filter_filter_condition_flare_rank" data-i18n-text></span>
-          <a id="filterCondition_flareRank_all">[All]</a>
           <a id="filterCondition_flareRank_clear">[Clear]</a>
           <div>
             <span class="element"
@@ -461,7 +452,6 @@
         </div>
         <div class="condition-group">
           <span data-i18n-key="browser_action_filter_filter_condition_availability" data-i18n-text></span>
-          <a id="filterCondition_availability_all">[All]</a>
           <a id="filterCondition_availability_clear">[Clear]</a>
           <div>
             <span class="element"

--- a/src/static/browser_action/index.html
+++ b/src/static/browser_action/index.html
@@ -52,6 +52,7 @@
                 data-i18n-text
               ></label
             ></span>
+            <!--
             <span class="element"
               ><input type="checkbox" id="summarySetting_scoreMax" name="summarySetting" value="scoreMax" /><label
                 for="summarySetting_scoreMax"
@@ -80,6 +81,7 @@
                 data-i18n-text
               ></label
             ></span>
+          -->
             <span class="element"
               ><input type="checkbox" id="summarySetting_scoreStatistics" name="summarySetting" value="scoreStatistics" /><label
                 for="summarySetting_scoreStatistics"

--- a/src/static/common/App.ts
+++ b/src/static/common/App.ts
@@ -56,7 +56,10 @@ export class App {
       savedConditions: [],
       conditions: {
         summary: { clearType: true },
-        filter: [],
+        filter: [
+          { attribute: 'playMode', values: [0] },
+          { attribute: 'availability', values: [0] },
+        ],
         sort: [],
       },
       saSettings: {

--- a/src/styles/ddr-components.css
+++ b/src/styles/ddr-components.css
@@ -333,7 +333,7 @@
   */
 
   @media (min-width: 1024px) {
-    #contentArea {
+    #contentArea:has(#mainPane) {
       display: grid;
       grid-template-columns: minmax(0, 1fr) 380px;
       gap: 10px;


### PR DESCRIPTION
## Summary

- フィルタ条件の `[All]` ボタンを廃止。チェックなし（= `[Clear]` 後）と表示結果が等価なため不要
- ゲームモード (SP/DP) をチェックボックスからラジオボタンに変更し、常にいずれかを選択する仕様に
  - `[Clear]` ボタンも廃止（ラジオボタンで必ず選択が必要なため）
  - 適用後に未選択状態になった場合（保存済みフィルタ読み込み時など）は SP にフォールバック
- 新規インストール時のデフォルトを **SP + 収録中のみ** に変更（既存ユーザの設定は維持）

## Test plan

- [x] `yarn build:dev` がエラーなく通ること
- [x] `yarn test` が全 578 件 pass すること
- [x] 新規プロファイルで起動時、SP のラジオが選択され、収録中のみにチェックが入った状態でリストが表示されること
- [x] 既存プロファイル（旧データあり）で起動時、保存済みの conditions が維持されること
- [x] playMode のラジオで SP ↔ DP が排他選択されること
- [x] 各フィルタ条件に `[All]` リンクが表示されないこと（`summarySetting` の `[All]` は残存）
- [x] 保存済みフィルタの読み込みで playMode が必ず 1 つ選択されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)