### PR TITLE
fix: デバッグログへの password 平文出力をマスクに変更

### DIFF
--- a/src/static/common/SkillAttackExporter.ts
+++ b/src/static/common/SkillAttackExporter.ts
@@ -63,7 +63,9 @@ export class SkillAttackExporter {
         return;
       }
       Logger.debug(skillAttackDataListDiff);
-      Logger.debug(skillAttackDataListDiff.urlSearchParams(ddrcode, password).toString());
+      const maskedParams = new URLSearchParams(skillAttackDataListDiff.urlSearchParams(ddrcode, password));
+      maskedParams.set('password', '***');
+      Logger.debug(maskedParams.toString());
 
       if (this.options.notSendDataToSkillAttack) {
         Logger.info(I18n.getMessage('log_message_done'));


### PR DESCRIPTION
## Summary

- `SkillAttackExporter.ts` のデバッグログで、URLSearchParams に含まれる `password` フィールドが `console.debug` に平文出力されていた問題を修正
- `urlSearchParams()` の戻り値を `new URLSearchParams(...)` でコピーし、コピー側の `password` 値を `'***'` に置き換えてからログ出力するよう変更
- 実際の skillattack.com への fetch 送信（77行目）は元のメソッド呼び出しをそのまま使用するため、送信内容への影響はなし

## Test plan

- [x] `yarn test` — 578 件・スナップショット 41 件すべて通過
- [x] `yarn build:dev` — ビルド成功
- [ ] Chrome に dev ビルドを読み込み、skillattack エクスポートを実行し DevTools Console で `password=***` と出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)