### PR TITLE
fix: セキュリティ脆弱性対応 (high CVE 3件 + moderate 2件)

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -11,8 +11,8 @@ npmMinimalAgeGate: 14d
 # 例外指定 (緊急 CVE 等で 14 日待てない場合のみバージョン固定で追加運用)
 # 解禁日を過ぎたら本セクションを削除する別 PR を作成すること
 npmPreapprovedPackages:
-  "@babel/plugin-transform-modules-systemjs": "7.29.4"  # GHSA-fv7c-fp4j-7gwp (HIGH 8.2), 2026-05-19 解禁
-  "fast-uri": "3.1.2"                                    # GHSA-v39h-62p7-jpjc + GHSA-q3j6-qgpj-74h6 (HIGH 7.5), 2026-05-19 解禁
+  - "@babel/plugin-transform-modules-systemjs@7.29.4"  # GHSA-fv7c-fp4j-7gwp (HIGH 8.2), 2026-05-19 解禁
+  - "fast-uri@3.1.2"                                    # GHSA-v39h-62p7-jpjc + GHSA-q3j6-qgpj-74h6 (HIGH 7.5), 2026-05-19 解禁
 
 # 旧 .npmrc の save-exact=true 相当 (^/~ を付けず完全固定)
 defaultSemverRangePrefix: ""

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -9,8 +9,10 @@ nodeLinker: node-modules
 npmMinimalAgeGate: 14d
 
 # 例外指定 (緊急 CVE 等で 14 日待てない場合のみバージョン固定で追加運用)
-# npmPreapprovedPackages:
-#   "<package-name>": "<exact-version>"
+# 解禁日を過ぎたら本セクションを削除する別 PR を作成すること
+npmPreapprovedPackages:
+  "@babel/plugin-transform-modules-systemjs": "7.29.4"  # GHSA-fv7c-fp4j-7gwp (HIGH 8.2), 2026-05-19 解禁
+  "fast-uri": "3.1.2"                                    # GHSA-v39h-62p7-jpjc + GHSA-q3j6-qgpj-74h6 (HIGH 7.5), 2026-05-19 解禁
 
 # 旧 .npmrc の save-exact=true 相当 (^/~ を付けず完全固定)
 defaultSemverRangePrefix: ""

--- a/package.json
+++ b/package.json
@@ -67,6 +67,8 @@
     "test/**/*.js": "prettier --write"
   },
   "resolutions": {
-    "picomatch": "4.0.4"
+    "picomatch": "4.0.4",
+    "@babel/plugin-transform-modules-systemjs": "7.29.4",
+    "fast-uri": "3.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "jest": "30.3.0",
     "jest-environment-jsdom": "30.3.0",
     "lint-staged": "16.4.0",
-    "postcss": "8.5.8",
+    "postcss": "8.5.13",
     "postcss-loader": "8.2.1",
     "prettier": "3.8.1",
     "tailwindcss": "4.2.2",
@@ -42,7 +42,6 @@
     "vue-eslint-parser": "10.4.0",
     "vue-loader": "17.4.2",
     "vue-style-loader": "4.1.3",
-    "vue-template-compiler": "2.7.16",
     "webpack": "5.105.4",
     "webpack-cli": "7.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2971,7 +2971,7 @@ __metadata:
     jest: "npm:30.3.0"
     jest-environment-jsdom: "npm:30.3.0"
     lint-staged: "npm:16.4.0"
-    postcss: "npm:8.5.8"
+    postcss: "npm:8.5.13"
     postcss-loader: "npm:8.2.1"
     prettier: "npm:3.8.1"
     tailwindcss: "npm:4.2.2"
@@ -2982,7 +2982,6 @@ __metadata:
     vue-eslint-parser: "npm:10.4.0"
     vue-loader: "npm:17.4.2"
     vue-style-loader: "npm:4.1.3"
-    vue-template-compiler: "npm:2.7.16"
     webpack: "npm:5.105.4"
     webpack-cli: "npm:7.0.2"
   languageName: unknown
@@ -3710,13 +3709,6 @@ __metadata:
     whatwg-mimetype: "npm:^4.0.0"
     whatwg-url: "npm:^14.0.0"
   checksum: 10c0/1b894d7d41c861f3a4ed2ae9b1c3f0909d4575ada02e36d3d3bc584bdd84278e20709070c79c3b3bff7ac98598cb191eb3e86a89a79ea4ee1ef360e1694f92ad
-  languageName: node
-  linkType: hard
-
-"de-indent@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "de-indent@npm:1.0.2"
-  checksum: 10c0/7058ce58abd6dfc123dd204e36be3797abd419b59482a634605420f47ae97639d0c183ec5d1b904f308a01033f473673897afc2bd59bc620ebf1658763ef4291
   languageName: node
   linkType: hard
 
@@ -4524,15 +4516,6 @@ __metadata:
   dependencies:
     function-bind: "npm:^1.1.2"
   checksum: 10c0/f5eb28c3fd0d3e4facd821c1eeee3836c37b70ab0b0fc532e8a39976e18fef43652415dadc52f8c7a5ff6d5ac93b7bef128789aa6f90f4e9b9a9083dce74ab38
-  languageName: node
-  linkType: hard
-
-"he@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "he@npm:1.2.0"
-  bin:
-    he: bin/he
-  checksum: 10c0/a27d478befe3c8192f006cdd0639a66798979dfa6e2125c6ac582a19a5ebfec62ad83e8382e6036170d873f46e4536a7e795bf8b95bf7c247f4cc0825ccc8c17
   languageName: node
   linkType: hard
 
@@ -6296,14 +6279,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:8.5.8":
-  version: 8.5.8
-  resolution: "postcss@npm:8.5.8"
+"postcss@npm:8.5.13":
+  version: 8.5.13
+  resolution: "postcss@npm:8.5.13"
   dependencies:
     nanoid: "npm:^3.3.11"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10c0/dd918f7127ee7c60a0295bae2e72b3787892296e1d1c3c564d7a2a00c68d8df83cadc3178491259daa19ccc54804fb71ed8c937c6787e08d8bd4bedf8d17044c
+  checksum: 10c0/3aa7c8cbdfbfd99b34406a433cef56d164dd135fc9cb9e63d487cc363291f877a55ec7b8ff6ec15348c17c2d98a43be46bfad671e6340403041a3e79f70c2f2f
   languageName: node
   linkType: hard
 
@@ -7325,16 +7308,6 @@ __metadata:
     hash-sum: "npm:^1.0.2"
     loader-utils: "npm:^1.0.2"
   checksum: 10c0/871362711561c817c6b96650cf4bcf422c51d46808650da7e6ec39499d76445d08a1f9f1d1aa0f6cffb191cd128fbd77b6e233d9689a87c21d7e546689bed04c
-  languageName: node
-  linkType: hard
-
-"vue-template-compiler@npm:2.7.16":
-  version: 2.7.16
-  resolution: "vue-template-compiler@npm:2.7.16"
-  dependencies:
-    de-indent: "npm:^1.0.2"
-    he: "npm:^1.2.0"
-  checksum: 10c0/66667ffd5095b707f169c902c4f1a011e9d5ab99fc228e4dac14eb5ca7f107ed99bff261b21578a4b391d2f3d320a8050e754404443472acad13ddaa4bd7bae2
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -888,9 +888,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-modules-systemjs@npm:^7.29.0":
-  version: 7.29.0
-  resolution: "@babel/plugin-transform-modules-systemjs@npm:7.29.0"
+"@babel/plugin-transform-modules-systemjs@npm:7.29.4":
+  version: 7.29.4
+  resolution: "@babel/plugin-transform-modules-systemjs@npm:7.29.4"
   dependencies:
     "@babel/helper-module-transforms": "npm:^7.28.6"
     "@babel/helper-plugin-utils": "npm:^7.28.6"
@@ -898,7 +898,7 @@ __metadata:
     "@babel/traverse": "npm:^7.29.0"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/44ea502f2c990398b7d9adc5b44d9e1810a0a5e86eebc05c92d039458f0b3994fe243efa9353b90f8a648d8a91b79845fb353d8679d7324cc9de0162d732771d
+  checksum: 10c0/1da94f89ef8ba1aa1501136a80eb4c010c6a19f5550e10db84677b3ccb7a4934c8098f2b5134def87cf513bf05747ffa523d33722a1ea5a5c8ef956e9136c4c2
   languageName: node
   linkType: hard
 
@@ -4215,10 +4215,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:^3.0.1":
-  version: 3.1.0
-  resolution: "fast-uri@npm:3.1.0"
-  checksum: 10c0/44364adca566f70f40d1e9b772c923138d47efeac2ae9732a872baafd77061f26b097ba2f68f0892885ad177becd065520412b8ffeec34b16c99433c5b9e2de7
+"fast-uri@npm:3.1.2":
+  version: 3.1.2
+  resolution: "fast-uri@npm:3.1.2"
+  checksum: 10c0/5b35641895959f3f7ab7a7b1b5542bded159346f25ec9f256817b206d50b64eda5828e90d605a2e2fc645c90519a7259c2bab2c942ee728c88b88e5be21b090d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- **high 3件 / moderate 2件**の脆弱性を修正（critical は 0 件）
- `npmMinimalAgeGate: 14d` により修正版が 14 日制限ブロック中のため、`.yarnrc.yml` の `npmPreapprovedPackages` で例外指定して先行インストールを許可

## 修正した脆弱性

| 重大度 | パッケージ | CVSS | Advisory | 対応内容 |
|---|---|---|---|---|
| HIGH | `@babel/plugin-transform-modules-systemjs` (推移依存) | 8.2 | [GHSA-fv7c-fp4j-7gwp](https://github.com/advisories/GHSA-fv7c-fp4j-7gwp) | `npmPreapprovedPackages` で 7.29.4 を許可 |
| HIGH | `fast-uri` (推移依存) host confusion | 7.5 | [GHSA-v39h-62p7-jpjc](https://github.com/advisories/GHSA-v39h-62p7-jpjc) | `npmPreapprovedPackages` で 3.1.2 を許可 |
| HIGH | `fast-uri` (推移依存) path traversal | 7.5 | [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6) | 同上（3.1.2 で両方解消） |
| MODERATE | `postcss` (直接依存) | 6.1 | [GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93) | 8.5.8 → 8.5.13 |
| MODERATE | `vue-template-compiler` (直接依存・未参照) | 4.2 | [GHSA-g3ch-rx76-35fx](https://github.com/advisories/GHSA-g3ch-rx76-35fx) | パッケージ削除（Vue3 移行時の置き忘れ） |

## 変更ファイル

- **`.yarnrc.yml`**: `npmPreapprovedPackages` を有効化し、`@babel/plugin-transform-modules-systemjs@7.29.4` / `fast-uri@3.1.2` を例外指定
- **`package.json`**: `postcss` 8.5.8 → 8.5.13、`vue-template-compiler` を削除

## 後続対応

`npmPreapprovedPackages` の例外指定は **2026-05-19 に 14 日制限が解禁**されるため、解禁後に別 PR で削除すること。

## Test plan

- [x] `yarn install` が正常完了し、`@babel/plugin-transform-modules-systemjs@7.29.4` / `fast-uri@3.1.2` が lockfile に反映されていること
- [x] `yarn npm audit --all --recursive` で high が 0 件になること
- [x] `yarn lint` が通ること
- [x] `yarn test` が通ること（スナップショット差分なし）
- [x] `yarn build` / `yarn build:dev` が正常完了すること
- [x] `dist/` を Chrome 拡張機能として読み込み、ポップアップ UI が正常に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)