### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## [0.6.0] - 2026-05-27
+
+### Added
+
+- Responsive two-pane layout for score list screen
+- Score list updates immediately when filter changes; close button hidden in two-pane mode
+
+### Changed
+
+- Revised filter specifications; removed score summary individual display settings from UI
+- Migrated package manager from Yarn Classic to Yarn Berry (v4) for supply chain hardening
+
+### Fixed
+
+- DDR World site redesign: updated parser, URL construction, and play count retrieval
+- Fixed `targetGameVersion` not being set in `updateScoreDetail`
+- Fixed FC/GFC labels in `CLEAR_TYPE_STRING` to current terminology
+- Fixed filter labels
+- Fixed duplicate scrolling in filter panel in two-pane mode
+- Fixed empty space at bottom of page in two-pane mode
+- Fixed drawer z-index layering issues
+- Fixed two-pane layout incorrectly applied to debug page
+- Fixed `applyConditions` error when deprecated `summarySetting` key existed in storage
+- Fixed `parseBemaniwikiNewSongTitles` always returning 0 results
+
+### Security
+
+- Masked password from debug logs
+- Updated dependencies to address CVE vulnerabilities (3 high, 2 moderate)
+
 ## [0.5.0] - 2026-05-09
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 Chrome Extension (Manifest V3) that collects and tracks DanceDanceRevolution scores from the DDR World official website. Built with Vue 3, webpack, and Jest.
 
-- **Version**: 0.5.0
+- **Version**: 0.6.0
 - **Node requirement**: >=18.12.0
 
 ## Commands

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "DDRScoreTracker",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Google Chrome extension for tracking your DanceDanceRevolution play records",
   "author": "Ryo Watanabe (https://github.com/ryowatanabe)",
   "license": "MIT",
@@ -54,6 +54,7 @@
     "build:dev": "tsc --noEmit && cross-env NODE_ENV=development webpack",
     "update-difficulties": "node --import './scripts/_ts-register.mjs' scripts/updateDifficultiesFromBemaniwiki.mjs",
     "update-contained-version": "node --import './scripts/_ts-register.mjs' scripts/updateContainedVersionFromBemaniwiki.mjs",
+    "package": "node scripts/packageExtension.mjs",
     "test": "jest",
     "test:e2e": "playwright test",
     "prepare": "husky"

--- a/scripts/packageExtension.mjs
+++ b/scripts/packageExtension.mjs
@@ -1,0 +1,31 @@
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { execFileSync } from 'child_process';
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const rootDir = join(__dirname, '..');
+const require = createRequire(import.meta.url);
+const { version } = require('../package.json');
+const distDir = join(rootDir, 'dist');
+const outputPath = join(rootDir, `DDRScoreTracker-v${version}.zip`);
+
+if (!existsSync(distDir)) {
+  console.error('Error: dist/ not found. Run `yarn build` first.');
+  process.exit(1);
+}
+
+// Zip dist/ contents with no "dist/" prefix so manifest.json is at zip root (required by Chrome Web Store).
+const pyCode = `
+import zipfile, os, sys
+zip_path = sys.argv[1]
+with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+    for root, dirs, files in os.walk('.'):
+        for f in files:
+            path = os.path.join(root, f)
+            zf.write(path)
+`;
+
+execFileSync('python3', ['-c', pyCode, outputPath], { cwd: distDir, stdio: 'inherit' });
+console.log(`Created: ${outputPath}`);


### PR DESCRIPTION
## Changes

### Added

- Responsive two-pane layout for score list screen
- Score list updates immediately when filter changes; close button hidden in two-pane mode

### Changed

- Revised filter specifications; removed score summary individual display settings from UI
- Migrated package manager from Yarn Classic to Yarn Berry (v4) for supply chain hardening

### Fixed

- DDR World site redesign: updated parser, URL construction, and play count retrieval
- Fixed `targetGameVersion` not being set in `updateScoreDetail`
- Fixed FC/GFC labels in `CLEAR_TYPE_STRING` to current terminology
- Fixed filter labels
- Fixed duplicate scrolling in filter panel in two-pane mode
- Fixed empty space at bottom of page in two-pane mode
- Fixed drawer z-index layering issues
- Fixed two-pane layout incorrectly applied to debug page
- Fixed `applyConditions` error when deprecated `summarySetting` key existed in storage
- Fixed `parseBemaniwikiNewSongTitles` always returning 0 results

### Security

- Masked password from debug logs
- Updated dependencies to address CVE vulnerabilities (3 high, 2 moderate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)