### PR TITLE
chore: release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.6.1] - 2026-05-27
+
+### Fixed
+
+- Filter panel not visible in two-pane mode in production build (Lightning CSS was converting `translate: none` to `transform: translate(0)`, failing to reset the CSS `translate` property)
+- `command not found: export` error on `yarn build` after migrating to Yarn Berry (replaced shell `export` with `cross-env`)
+
 ## [0.6.0] - 2026-05-27
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 Chrome Extension (Manifest V3) that collects and tracks DanceDanceRevolution scores from the DDR World official website. Built with Vue 3, webpack, and Jest.
 
-- **Version**: 0.6.0
+- **Version**: 0.6.1
 - **Node requirement**: >=18.12.0
 
 ## Commands

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lint": "ESLINT_USE_FLAT_CONFIG=true eslint -c eslint.config.mjs",
     "prettier": "prettier \"src/**/*.{js,vue,json,html}\" \"test/**/*.js\"",
     "prettier:write": "yarn prettier --write",
-    "build": "yarn clean; export NODE_OPTIONS=--openssl-legacy-provider; tsc --noEmit && cross-env NODE_ENV=production webpack",
+    "build": "yarn clean && cross-env NODE_OPTIONS=--openssl-legacy-provider tsc --noEmit && cross-env NODE_OPTIONS=--openssl-legacy-provider NODE_ENV=production webpack",
     "build:dev": "tsc --noEmit && cross-env NODE_ENV=development webpack",
     "update-difficulties": "node --import './scripts/_ts-register.mjs' scripts/updateDifficultiesFromBemaniwiki.mjs",
     "update-contained-version": "node --import './scripts/_ts-register.mjs' scripts/updateContainedVersionFromBemaniwiki.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "DDRScoreTracker",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Google Chrome extension for tracking your DanceDanceRevolution play records",
   "author": "Ryo Watanabe (https://github.com/ryowatanabe)",
   "license": "MIT",

--- a/src/styles/ddr-components.css
+++ b/src/styles/ddr-components.css
@@ -350,8 +350,7 @@
       grid-column: 2;
       position: sticky;
       top: 5px;
-      transform: none;
-      translate: none;
+      translate: 0;
       width: auto;
       max-height: none;
       overflow: visible;


### PR DESCRIPTION
## Changes

### Fixed

- Filter panel not visible in two-pane mode in production build (Lightning CSS was converting `translate: none` to `transform: translate(0)`, failing to reset the CSS `translate` property)
- `command not found: export` error on `yarn build` after migrating to Yarn Berry (replaced shell `export` with `cross-env`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)