### PR TITLE
fix: ドロワーの重なり順を修正 (前回の更新一覧 > メニュー)

### DIFF
--- a/src/styles/ddr-components.css
+++ b/src/styles/ddr-components.css
@@ -209,8 +209,18 @@
   .drawer {
     @apply z-10 fixed top-0 left-0 box-border w-full bg-black border border-white p-[5px] translate-x-full;
   }
+  /* 重なり順 (上→下): log > diff > menu/filter */
   #logContainer.drawer {
     z-index: 20;
+  }
+  #logBackground.drawer-background {
+    z-index: 19;
+  }
+  #diffContainer.drawer {
+    z-index: 15;
+  }
+  #diffBackground.drawer-background {
+    z-index: 14;
   }
   .drawer.not-initialized {
     @apply transition-none;


### PR DESCRIPTION
## Summary

- `#diffContainer` と `#menuContainer` が同じ `z-index: 10` だったため、DOM 順でメニューが「前回の更新一覧」の手前に表示されていた
- 各ドロワーに個別の z-index を設定し、`log(20) > diff(15) > menu(10)` の重なり順に修正

| 要素 | 変更前 | 変更後 |
|---|---|---|
| `#logContainer` | 20 | 20 (変更なし) |
| `#logBackground` | 9 (既定) | 19 |
| `#diffContainer` | 10 (既定) | 15 |
| `#diffBackground` | 9 (既定) | 14 |
| `#menuContainer` | 10 (既定) | 10 (変更なし) |
| `#menuBackground` | 9 (既定) | 9 (変更なし) |

## Test plan

- [x] メニューを開き「前回の更新一覧」を開く → diff ドロワーがメニューより手前に表示され、背後のメニューが暗くなること
- [x] その状態でログを開く → ログが最前面に来ること
- [x] フィルタ・メニュー単体の表示が従来通りであること (デスクトップ幅含む)

🤖 Generated with [Claude Code](https://claude.com/claude-code)