### PR TITLE
chore: release v0.6.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .DS_Store
 
+# Release zip packages
+*.zip
+
 # Claude Code local settings (personal, not shared)
 .claude/settings.local.json
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.6.2] - 2026-05-28
+
+### Fixed
+
+- Updated difficulty parser for DDR World music detail pages to match the redesigned site structure
+- Fixed drawer z-index layering so the recent updates panel no longer appears above the menu
+
 ## [0.6.1] - 2026-05-27
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 Chrome Extension (Manifest V3) that collects and tracks DanceDanceRevolution scores from the DDR World official website. Built with Vue 3, webpack, and Jest.
 
-- **Version**: 0.6.1
+- **Version**: 0.6.2
 - **Node requirement**: >=18.12.0
 
 ## Commands

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "DDRScoreTracker",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Google Chrome extension for tracking your DanceDanceRevolution play records",
   "author": "Ryo Watanabe (https://github.com/ryowatanabe)",
   "license": "MIT",


### PR DESCRIPTION
## Changes

### Fixed

- Updated difficulty parser for DDR World music detail pages to match the redesigned site structure
- Fixed drawer z-index layering so the recent updates panel no longer appears above the menu