### PR TITLE
chore(deps): 不要になった resolutions と npmPreapprovedPackages を削除

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -8,11 +8,11 @@ nodeLinker: node-modules
 # https://yarnpkg.com/configuration/yarnrc#npmMinimalAgeGate
 npmMinimalAgeGate: 14d
 
-# 例外指定 (緊急 CVE 等で 14 日待てない場合のみバージョン固定で追加運用)
-# 解禁日を過ぎたら本セクションを削除する別 PR を作成すること
-npmPreapprovedPackages:
-  - "@babel/plugin-transform-modules-systemjs@7.29.4"  # GHSA-fv7c-fp4j-7gwp (HIGH 8.2), 2026-05-19 解禁
-  - "fast-uri@3.1.2"                                    # GHSA-v39h-62p7-jpjc + GHSA-q3j6-qgpj-74h6 (HIGH 7.5), 2026-05-19 解禁
+# 緊急 CVE 等で 14 日待てない場合のみ、以下の形式で例外を追加する。
+# 解禁日を過ぎたら削除する別 PR を作成すること。
+#
+# npmPreapprovedPackages:
+#   - "<package>@<version>"  # <GHSA-ID> (<severity>), <解禁日> 解禁
 
 # 旧 .npmrc の save-exact=true 相当 (^/~ を付けず完全固定)
 defaultSemverRangePrefix: ""

--- a/package.json
+++ b/package.json
@@ -66,10 +66,5 @@
     ],
     "src/**/*.{json,html}": "prettier --write",
     "test/**/*.js": "prettier --write"
-  },
-  "resolutions": {
-    "picomatch": "4.0.4",
-    "@babel/plugin-transform-modules-systemjs": "7.29.4",
-    "fast-uri": "3.1.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,6 +36,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/code-frame@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/code-frame@npm:7.29.7"
+  dependencies:
+    "@babel/helper-validator-identifier": "npm:^7.29.7"
+    js-tokens: "npm:^4.0.0"
+    picocolors: "npm:^1.1.1"
+  checksum: 10c0/169fc2080169a40c1760155eaaaf739bcb882df0bec76a83adbda5493645bc17270a3434b8848c494b1933e96fe1d147370001e3cda09a39f43ae30f08ef2069
+  languageName: node
+  linkType: hard
+
 "@babel/compat-data@npm:^7.28.6, @babel/compat-data@npm:^7.29.0":
   version: 7.29.0
   resolution: "@babel/compat-data@npm:7.29.0"
@@ -99,6 +110,19 @@ __metadata:
     "@jridgewell/trace-mapping": "npm:^0.3.28"
     jsesc: "npm:^3.0.2"
   checksum: 10c0/349086e6876258ef3fb2823030fee0f6c0eb9c3ebe35fc572e16997f8c030d765f636ddc6299edae63e760ea6658f8ee9a2edfa6d6b24c9a80c917916b973551
+  languageName: node
+  linkType: hard
+
+"@babel/generator@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/generator@npm:7.29.7"
+  dependencies:
+    "@babel/parser": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+    "@jridgewell/gen-mapping": "npm:^0.3.12"
+    "@jridgewell/trace-mapping": "npm:^0.3.28"
+    jsesc: "npm:^3.0.2"
+  checksum: 10c0/9bf72b01b5bd0ea5b1288a0e37dbd360bff2f2b1ce73342c0d40fb3db2ec3dc004ada5ffa925c5e12939a416eed59e600d562b8ecd938ce0d27dfd0eb6c6c2b7
   languageName: node
   linkType: hard
 
@@ -176,6 +200,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-globals@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-globals@npm:7.29.7"
+  checksum: 10c0/f38417c40b1129a1b2b519ca961b9040c8827d1444fd74068702286b91b77089431dc76b6b9d5c1496e5da2a4f3ad329c6946e688ba3fa0d1d0b3d2b4f34f36a
+  languageName: node
+  linkType: hard
+
 "@babel/helper-member-expression-to-functions@npm:^7.28.5":
   version: 7.28.5
   resolution: "@babel/helper-member-expression-to-functions@npm:7.28.5"
@@ -196,6 +227,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-module-imports@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-module-imports@npm:7.29.7"
+  dependencies:
+    "@babel/traverse": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+  checksum: 10c0/6adf60d97356027413342a092f818d9678c4f5caff716a33e3284b5ae14e47a9e88059d421dde4ee4894691260039a12602c0e7becadc175602194b40dfa345d
+  languageName: node
+  linkType: hard
+
 "@babel/helper-module-transforms@npm:^7.27.1, @babel/helper-module-transforms@npm:^7.28.6":
   version: 7.28.6
   resolution: "@babel/helper-module-transforms@npm:7.28.6"
@@ -206,6 +247,19 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: 10c0/6f03e14fc30b287ce0b839474b5f271e72837d0cafe6b172d759184d998fbee3903a035e81e07c2c596449e504f453463d58baa65b6f40a37ded5bec74620b2b
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-transforms@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-module-transforms@npm:7.29.7"
+  dependencies:
+    "@babel/helper-module-imports": "npm:^7.29.7"
+    "@babel/helper-validator-identifier": "npm:^7.29.7"
+    "@babel/traverse": "npm:^7.29.7"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 10c0/ee5a2172c24a42be696836f4b0d947489c9729d8adf5821885cf77d1ad5333e3c447368e9a71f67df1099570490553dccf9f888ef0a92a48aa63cb086bd8c7e1
   languageName: node
   linkType: hard
 
@@ -222,6 +276,13 @@ __metadata:
   version: 7.28.6
   resolution: "@babel/helper-plugin-utils@npm:7.28.6"
   checksum: 10c0/3f5f8acc152fdbb69a84b8624145ff4f9b9f6e776cb989f9f968f8606eb7185c5c3cfcf3ba08534e37e1e0e1c118ac67080610333f56baa4f7376c99b5f1143d
+  languageName: node
+  linkType: hard
+
+"@babel/helper-plugin-utils@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-plugin-utils@npm:7.29.7"
+  checksum: 10c0/380477a06133274a2759f9355929cb60a95e8b8fee624a1ae1fa349e1d1645b89daca456f72833f6d1062bffa12ee4271c5bf0cc5a61c0166cdc24c7591e2408
   languageName: node
   linkType: hard
 
@@ -268,10 +329,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-string-parser@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-string-parser@npm:7.29.7"
+  checksum: 10c0/194bc0f1716e396d5ffde56ad6119745fb9557662c98611590e5e454906783a4ccb21ce93056b8eb69a4909044834e45d96e50ac695bbe9e3221648fe033c06c
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-identifier@npm:^7.28.5":
   version: 7.28.5
   resolution: "@babel/helper-validator-identifier@npm:7.28.5"
   checksum: 10c0/42aaebed91f739a41f3d80b72752d1f95fd7c72394e8e4bd7cdd88817e0774d80a432451bcba17c2c642c257c483bf1d409dd4548883429ea9493a3bc4ab0847
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-identifier@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-validator-identifier@npm:7.29.7"
+  checksum: 10c0/4795354e7ae0dcafa72de1cd04ec51252dc1498517170beaf019e03effc5b7bf13c6b21a3949a77e07b8125be7f106ed1131350d8ebd4566ae874094a726d62b
   languageName: node
   linkType: hard
 
@@ -311,6 +386,17 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 10c0/e5a4e69e3ac7acdde995f37cf299a68458cfe7009dff66bd0962fd04920bef287201169006af365af479c08ff216bfefbb595e331f87f6ae7283858aebbc3317
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/parser@npm:7.29.7"
+  dependencies:
+    "@babel/types": "npm:^7.29.7"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 10c0/65133038f80b54a714d6027cb77cee3f9a6b5c4c6842ce674301e13947cbcbfa8055e63acaf1b84c085d34226a14425b2c2b97b829e0e226d2e8f1299942a51d
   languageName: node
   linkType: hard
 
@@ -888,17 +974,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-modules-systemjs@npm:7.29.4":
-  version: 7.29.4
-  resolution: "@babel/plugin-transform-modules-systemjs@npm:7.29.4"
+"@babel/plugin-transform-modules-systemjs@npm:^7.29.0":
+  version: 7.29.7
+  resolution: "@babel/plugin-transform-modules-systemjs@npm:7.29.7"
   dependencies:
-    "@babel/helper-module-transforms": "npm:^7.28.6"
-    "@babel/helper-plugin-utils": "npm:^7.28.6"
-    "@babel/helper-validator-identifier": "npm:^7.28.5"
-    "@babel/traverse": "npm:^7.29.0"
+    "@babel/helper-module-transforms": "npm:^7.29.7"
+    "@babel/helper-plugin-utils": "npm:^7.29.7"
+    "@babel/helper-validator-identifier": "npm:^7.29.7"
+    "@babel/traverse": "npm:^7.29.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/1da94f89ef8ba1aa1501136a80eb4c010c6a19f5550e10db84677b3ccb7a4934c8098f2b5134def87cf513bf05747ffa523d33722a1ea5a5c8ef956e9136c4c2
+  checksum: 10c0/7b950bcc4a4b077b742b9299c8c9d4285e15854e23816d0b1c1177fafda4c153f3c3c4487c1b965afbf7a69a8788fc75656d0c591b91f0a5a543faabe738ca58
   languageName: node
   linkType: hard
 
@@ -1327,6 +1413,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/template@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/template@npm:7.29.7"
+  dependencies:
+    "@babel/code-frame": "npm:^7.29.7"
+    "@babel/parser": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+  checksum: 10c0/8bb7f900dcab0e9e1c5ffbc33ca10e0d26b7b2e2ca804becb73ee771b9c4ed6e2908a4ae4a14c08560febb45d2b6b9a173955e42ad404d05f8b04840a14d9c58
+  languageName: node
+  linkType: hard
+
 "@babel/traverse@npm:^7.27.1, @babel/traverse@npm:^7.28.5, @babel/traverse@npm:^7.28.6, @babel/traverse@npm:^7.29.0":
   version: 7.29.0
   resolution: "@babel/traverse@npm:7.29.0"
@@ -1342,6 +1439,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/traverse@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/traverse@npm:7.29.7"
+  dependencies:
+    "@babel/code-frame": "npm:^7.29.7"
+    "@babel/generator": "npm:^7.29.7"
+    "@babel/helper-globals": "npm:^7.29.7"
+    "@babel/parser": "npm:^7.29.7"
+    "@babel/template": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+    debug: "npm:^4.3.1"
+  checksum: 10c0/e256a1fbdb956555b76f3c285b1e453f6bedec8b3afb61751d99d933efd11c7d79caf5ddf2493570058a9f7deaa1b48324380d7c1aa1443fd9508becbf56331a
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.27.1, @babel/types@npm:^7.27.3, @babel/types@npm:^7.28.2, @babel/types@npm:^7.28.5, @babel/types@npm:^7.28.6, @babel/types@npm:^7.29.0, @babel/types@npm:^7.4.4":
   version: 7.29.0
   resolution: "@babel/types@npm:7.29.0"
@@ -1349,6 +1461,16 @@ __metadata:
     "@babel/helper-string-parser": "npm:^7.27.1"
     "@babel/helper-validator-identifier": "npm:^7.28.5"
   checksum: 10c0/23cc3466e83bcbfab8b9bd0edaafdb5d4efdb88b82b3be6728bbade5ba2f0996f84f63b1c5f7a8c0d67efded28300898a5f930b171bb40b311bca2029c4e9b4f
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/types@npm:7.29.7"
+  dependencies:
+    "@babel/helper-string-parser": "npm:^7.29.7"
+    "@babel/helper-validator-identifier": "npm:^7.29.7"
+  checksum: 10c0/b6623994c69717fa27294f5fa46d59140338e2d86c6c1c13085c84ef7d53086ee357fbf4fe9abe3dd3da75734dc77c4c0df2f90fb29e667558bb3b3fb705e88f
   languageName: node
   linkType: hard
 
@@ -4159,10 +4281,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:3.1.2":
-  version: 3.1.2
-  resolution: "fast-uri@npm:3.1.2"
-  checksum: 10c0/5b35641895959f3f7ab7a7b1b5542bded159346f25ec9f256817b206d50b64eda5828e90d605a2e2fc645c90519a7259c2bab2c942ee728c88b88e5be21b090d
+"fast-uri@npm:^3.0.1":
+  version: 3.1.4
+  resolution: "fast-uri@npm:3.1.4"
+  checksum: 10c0/f90948821ceb49980f64f89b8216ba498f5957f26035be813526a55b6145d26cbd63ef5618d5205a3292b31edc9c08589749350cd72bd86c7095eb434dceb757
   languageName: node
   linkType: hard
 
@@ -6037,10 +6159,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:4.0.4":
-  version: 4.0.4
-  resolution: "picomatch@npm:4.0.4"
-  checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
+"picomatch@npm:^2.0.4, picomatch@npm:^2.3.1":
+  version: 2.3.2
+  resolution: "picomatch@npm:2.3.2"
+  checksum: 10c0/a554d1709e59be97d1acb9eaedbbc700a5c03dbd4579807baed95100b00420bc729335440ef15004ae2378984e2487a7c1cebd743cfdb72b6fa9ab69223c0d61
+  languageName: node
+  linkType: hard
+
+"picomatch@npm:^4.0.3, picomatch@npm:^4.0.4, picomatch@npm:^4.0.5":
+  version: 4.0.5
+  resolution: "picomatch@npm:4.0.5"
+  checksum: 10c0/947bc6b6e1ff1e6c5aaf95b107a0839d12802f4f7b867663f67d47accba939ca1cb582cf99dfc30438efa1c4648ac5990967e783e8929c36b03e8440704ef1bd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
依存ライブラリ更新計画の **PR#2 / 全5PR** です。バージョンを上げる前に、土台となる依存解決の設定を掃除します。

## 背景

`package.json` の `resolutions` 3 件と `.yarnrc.yml` の `npmPreapprovedPackages` 2 件は、
いずれも「上流が脆弱性パッチに追いつくまで」の一時的な措置として導入されたものでした。

調査の結果、**3 件とも上流が既に追いついており、松葉杖が不要になっている**ことが分かりました。
さらに `npmPreapprovedPackages` の 2 件は `.yarnrc.yml` のコメントに
「2026-05-19 解禁」と明記されており、**2.5 ヶ月間削除し忘れられていた**状態でした。

## `resolutions` の削除

削除後に `yarn why` と `node_modules` 上の実体で解決バージョンを**実測**しました。

| パッケージ | 削除前 | 削除後（実測） | 必要パッチ版 | 判定 |
|---|---|---|---|---|
| `picomatch` (anymatch 経由) | 4.0.4 **強制** | **2.3.2** | 2.3.2 | OK |
| `picomatch` (micromatch 経由) | 4.0.4 **強制** | **2.3.2** | 2.3.2 | OK |
| `picomatch` (jest / lint-staged 等) | 4.0.4 | **4.0.5** | 4.0.4 | OK |
| `fast-uri` | 3.1.2 | **3.1.4** | 後述 | 前進 |
| `@babel/plugin-transform-modules-systemjs` | 7.29.4 | **7.29.7** | 7.29.4 | OK |

### picomatch は残す方がリスクだった

`"picomatch": "4.0.4"` はパス指定のない全マッチ resolution だったため、
**picomatch 2.x を要求している依存にまで 4.0.4 を強制**していました。

```
anymatch@3.1.3   -> ^2.0.4   ← 2.x を要求しているのに 4.0.4 を強制されていた
micromatch@4.0.8 -> ^2.3.1   ← 同上
```

picomatch 2→4 には破壊的変更があり、これは「glob マッチングが静かに壊れる」種類のリスクです。

そして**そのリスクを負う必要が最初から在りませんでした**。
GHSA-c2c7-rcm5-vvqj (high, ReDoS) と GHSA-3v7f-55p6-f55p (medium) は
いずれも各系統で個別にパッチが出ています。

| 系統 | 脆弱範囲 | パッチ版 |
|---|---|---|
| 2.x | `< 2.3.2` | 2.3.2 |
| 3.x | `>= 3.0.0, < 3.0.2` | 3.0.2 |
| 4.x | `>= 4.0.0, < 4.0.4` | 4.0.4 |

削除により `anymatch` / `micromatch` は正しく 2.3.2（パッチ済み）を取得し、
その他は 4.0.5（パッチ済み）を取得しています。**全ラインが自動的にパッチ版以上**になりました。

### resolution は「古い版に固定する足枷」でもあった

削除により 4.0.4→4.0.5 / 3.1.2→3.1.4 / 7.29.4→7.29.7 と、いずれも最新パッチへ前進しました。

## `npmPreapprovedPackages` の削除

2 件とも既に 14 日ゲートを通過できる状態で、preapproval なしで解決されます。
`.yarnrc.yml` のコメントに記載された運用ルール
（「解禁日を過ぎたら本セクションを削除する別 PR を作成すること」）に沿った削除です。

将来の例外追加に備え、記法のテンプレートをコメントとして残しています。

## 既知の問題（本 PR では解消しない）

**`fast-uri` は 3.1.4 になりましたが、`>=3.0.0 <3.1.5` を脆弱とする advisory に依然該当します。**

計画時に確認した 2 件の GHSA（パッチ版 3.1.1 / 3.1.2）とは別の advisory が存在していました。
ただし**削除前の 3.1.2 も同じ範囲に該当しており、本 PR で悪化はしていません**（3.1.2 → 3.1.4 と前進）。

パッチ版 3.1.5 は 2026-07-31 リリースのため `npmMinimalAgeGate: 14d` により現時点では取得できません
（解禁 2026-08-14）。`ajv` 経由の devDependency であり、配布物には含まれません。

## 検証結果

| 検証 | 結果 |
|---|---|
| `yarn lint` | exit 0 |
| `yarn tsc --noEmit` | exit 0 |
| `yarn test` | **54 suites / 578 tests / 41 snapshots 全 pass** |
| `yarn build` | 成功 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
