### PR TITLE
ci: actions/checkout と actions/setup-node を v7 に更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
 


### PR DESCRIPTION
PR#696 の CI 実行時に GitHub Actions から deprecation 警告が出たため対応します。
#693 で CI を新設した際に、古いメジャーバージョンを指定していたことによるものです。

## 警告内容

```
! Node.js 20 is deprecated. The following actions target Node.js 20 but are being
  forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4
```

現時点では Node 24 で強制実行されて動作していますが、放置すると CI が突然停止します。

## 変更内容

| Action | 変更 | 最新版 |
|---|---|---|
| `actions/checkout` | v4 → **v7** | v7.0.1 (2026-07-20) |
| `actions/setup-node` | v4 → **v7** | v7.0.0 (2026-07-14) |

## 破壊的変更の影響確認

メジャー 3 つ飛ばしのため、v5 / v6 / v7 のリリースノートを確認しました。
**いずれも本リポジトリには影響しません。**

### setup-node

- **v5**: `package.json` に `packageManager` フィールドがあると**自動キャッシュが有効化**される
  → 本リポジトリは `"packageManager": "yarn@4.14.1"` を持つため、一度は該当した
- **v6**: その自動キャッシュが **npm のみに限定**された
  → yarn を使う本リポジトリでは無効。**結果として現在と同じ挙動（キャッシュなし）**になる
- **v7**: `cache-primary-key` / `cache-matched-key` の output 追加、ESM 移行。入力仕様の変更なし

### checkout

- **v5**: Node 24 化（runner v2.327.1 以降が必要。GitHub ホストランナーは条件を満たす）
- **v6**: 認証情報を別ファイルに永続化
- **v7**: fork PR の checkout をブロック。ただし対象は `pull_request_target` と `workflow_run` のみで、
  本ワークフローは `pull_request` トリガのため**影響しない**

現在このワークフローが使用している入力は `node-version` のみで、仕様変更はありません。

## 検証

本 PR は CI 自身の変更であるため、**この PR で CI が緑になること、かつ
deprecation 警告が消えること**が検証になります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
