### PR TITLE
chore(deps): Dependabot に devDependencies のグルーピングを導入

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,42 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# Dependabot version updates
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
+  - package-ecosystem: "npm" # Yarn Berry も npm ecosystem として扱われる
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+
+    # グルーピング後に開く PR は「devDependencies の minor/patch まとめ 1 件」+
+    # 「major 個別数件」程度に収まるため 10 で十分な余裕がある。
+    # セキュリティ更新 PR はこの上限の対象外 (カウントもされない)。
     open-pull-requests-limit: 10
+
+    # サプライチェーン攻撃対策。.yarnrc.yml の npmMinimalAgeGate と値を揃えること。
+    # cooldown を外すと Dependabot 既定の 3 日になり、npmMinimalAgeGate に弾かれて
+    # yarn install が失敗する PR が量産される。
+    #
+    # 両者は役割が異なるため片方には寄せられない:
+    #   - cooldown          : version update PR を作らせないための入口側の制御。
+    #                         security update には適用されない。
+    #   - npmMinimalAgeGate : install 時に実際に取り込みを拒否する強制力。
+    #                         手動の yarn up や security update PR にも効く (→ #701)。
+    #
+    # semver-major/minor/patch-days は未指定なら default-days が使われるので指定しない。
     cooldown:
       default-days: 14
-      semver-major-days: 14
-      semver-minor-days: 14
-      semver-patch-days: 14
+
+    # 全依存が devDependencies のため、minor/patch を 1 PR にまとめて PR 数を抑える。
+    # これをやらないと毎週数件〜十数件の PR が開き、open-pull-requests-limit に
+    # 張り付いて新しい更新 PR が作られなくなる (→ #702 で起きた陳腐化の原因)。
+    #
+    # major は破壊的変更の切り分け・revert 単位を保つため個別 PR のままにする。
+    # security update はグループ化しない。npmMinimalAgeGate で 1 件でも解禁待ちに
+    # なると、まとめた PR 全体が取り込めなくなるため (→ #701)。
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Closes #702

## 背景

`.github/dependabot.yml` の `open-pull-requests-limit: 10` に張り付いた結果、Dependabot が新しい version update PR を作れず、#662〜#671 が 2 ヶ月半放置されて全件陳腐化した。原因側 (PR 数そのもの) を減らす。

## 変更内容

### 1. `groups` の導入

```yaml
groups:
  dev-dependencies:
    dependency-type: "development"
    update-types: ["minor", "patch"]
```

本プロジェクトは `dependencies` が 0 件で全依存が devDependencies のため、minor/patch がまとまって毎週 1 PR に激減する。

- **major は個別 PR のまま**: 破壊的変更の切り分けと revert 単位を保つため
- **security update はグループ化しない**: `npmMinimalAgeGate` で 1 件でも解禁待ちになるとまとめた PR 全体が取り込めなくなるため (#701 がその状況)

### 2. `open-pull-requests-limit` は 10 を維持

グルーピング後の定常状態は「まとめ 1 件 + major 数件」で 10 は十分な余裕がある。security update PR はこの上限の対象外でカウントもされない。

### 3. `cooldown` と `npmMinimalAgeGate` は両方維持

**cooldown は version update にのみ適用され、security update には適用されない**ため、両者は役割が異なり片方には寄せられない。

| | 役割 | security update |
|---|---|---|
| `cooldown: 14` | Dependabot に PR を作らせない入口側の制御 | 適用外 |
| `npmMinimalAgeGate: 14d` | install 時に実際に拒否する強制力 (手動 `yarn up` にも効く) | 効く |

cooldown を外すと Dependabot 既定の 3 日に戻り、`npmMinimalAgeGate` に弾かれて `yarn install` が失敗する PR が量産される。よって両方 14 日で維持し、値を揃える必要がある旨をコメントで明文化した。

ただし `semver-major/minor/patch-days` は未指定なら `default-days` が使われるため、14 の 4 重指定を `default-days: 14` の 1 行に整理した。

### 4. 陳腐化 PR の定期掃除運用 → 不要と判断

陳腐化は limit 枯渇で Dependabot が PR を作り直せなくなった結果であり、原因側を潰せば自然に解消する。グルーピング後は毎週同じブランチが最新バージョンで再生成されるため、掃除用ワークフローの追加は過剰と判断した。

## 確認

- YAML の構文と Dependabot スキーマへの適合を parse して確認済み
- ソースコードの変更はないため lint/test/build には影響しない

## スコープ外

`.github/workflows/` の GitHub Actions は Dependabot の管理対象外のまま (#697 は手動更新)。`package-ecosystem: "github-actions"` の追加は PR 数を増やす変更のため本 PR では見送った。

🤖 Generated with [Claude Code](https://claude.com/claude-code)