### PR TITLE
chore(deps): typescript の major 更新を Dependabot の対象外にする

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,9 +23,13 @@ updates:
     #   - npmMinimalAgeGate : install 時に実際に取り込みを拒否する強制力。
     #                         手動の yarn up や security update PR にも効く (→ #701)。
     #
-    # semver-major/minor/patch-days は未指定なら default-days が使われるので指定しない。
+    # semver-major/minor/patch-days は未指定でも default-days が使われるが、ジョブ定義上は
+    # 0 として直列化され「未指定」か「cooldown なし」か区別できないため、明示しておく。
     cooldown:
       default-days: 14
+      semver-major-days: 14
+      semver-minor-days: 14
+      semver-patch-days: 14
 
     # 全依存が devDependencies のため、minor/patch を 1 PR にまとめて PR 数を抑える。
     # これをやらないと毎週数件〜十数件の PR が開き、open-pull-requests-limit に
@@ -40,3 +44,13 @@ updates:
         update-types:
           - "minor"
           - "patch"
+
+    # TypeScript 7 は Go 実装への書き換えで lib/_tsc.js を同梱しなくなり、Yarn の
+    # builtin<compat/typescript> パッチが ENOENT で落ちる。加えて @typescript-eslint が
+    # peer で typescript <6.1.0 を要求しており、現時点の toolchain では採用できない。
+    # 更新のたびにジョブ全体が exit 1 になるため major のみ除外する。
+    # 解除条件と確認手順は #708 に記載。両方解消したら本エントリを削除すること。
+    ignore:
+      - dependency-name: "typescript"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
Refs #708

## 背景

PR #704 マージ後の Dependabot 実行 ([run 30974518707](https://github.com/ryowatanabe/DDRScoreTracker/actions/runs/30974518707)) が failure になったため調査した。

失敗は 2 系統あり、**どちらも #704 の変更が原因ではなく、マージ前から存在していた別々の問題**だった。

| ジョブ | 対象 | 原因 | 本 PR の扱い |
|---|---|---|---|
| version update | `typescript` 6.0.3 → 7.0.2 | Yarn の builtin patch が TS7 で壊れる + peer 制約 | **本 PR で対処** |
| security update | `fast-uri` 3.1.5 | `npmMinimalAgeGate` で 2026-08-14 まで取り込めない | #701 で対応（変更なし） |

なお同じ run で babel の major 3 件 (#705〜#707) は正常に作成されており、#704 で導入したグルーピングは設計どおり動作している。

## typescript の失敗内容

Dependabot が実行したコマンドと出力（ローカルでも同一エラー・exit 1 を再現済み）:

```
$ corepack yarn add typescript@7.0.2 --mode=update-lockfile

YN0060: typescript is listed by your project with version 7.0.2, which doesn't satisfy
        what @typescript-eslint/eslint-plugin and other dependencies request (>=4.8.4 <6.1.0).
YN0001: Error: typescript@patch:typescript@npm%3A7.0.2#optional!builtin<compat/typescript>...
        ENOENT: no such file or directory, lstat '/node_modules/typescript/lib/_tsc.js'
```

原因は 2 つ重なっている。

1. **致命的なのは Yarn 側** — Yarn 4.14.1 は typescript に `builtin<compat/typescript>` パッチを自動適用するが、TypeScript 7 は Go 実装への書き換えで `lib/_tsc.js` を同梱しなくなったため ENOENT で落ちる。
2. **peer 制約** — `@typescript-eslint/eslint-plugin` 8.65.0 が `typescript >=4.8.4 <6.1.0` を要求。

いずれにせよ現時点の toolchain では TypeScript 7 を採用できないため、major のみ ignore して週次実行の失敗を止める。

## 変更内容

### 1. `ignore` に typescript の major を追加

```yaml
ignore:
  - dependency-name: "typescript"
    update-types:
      - "version-update:semver-major"
```

TS 6.x の minor/patch は従来どおり `dev-dependencies` グループで届く。解除条件と確認手順は #708 に記載し、コメントから参照している。

### 2. `cooldown` の `semver-*-days` を明示指定に戻す

#704 で「未指定なら `default-days` が使われる」ため削除したが、ジョブ定義を確認すると `{"default-days":14,"semver-major-days":0,...}` と直列化されており、`0` が「未指定」か「cooldown なし」か区別できなかった。サプライチェーン対策は推測に頼りたくないため明示に戻す。

今回作成された major PR はいずれも公開から 14 日以上経過（babel 8.0.x は 2026-06 公開）しており、cooldown がすり抜けた証拠はない。予防的な変更。

## 確認

- YAML の構文と Dependabot スキーマへの適合を parse して確認済み
- `corepack yarn add typescript@7.0.2 --mode=update-lockfile` をローカルで実行し、Dependabot と同一のエラー・exit 1 を再現（`package.json` / `yarn.lock` は revert 済み）
- ソースコードの変更はないため lint/test/build には影響しない

## スコープ外

- #705〜#707 (babel 8 系 major): 破壊的変更の検証が必要なため別途対応
- #701 (fast-uri ほか): 2026-08-14 の解禁を待って対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)