### PR TITLE
docs: CLAUDE.md を実態に合わせて修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,22 +2,37 @@
 
 ## Project Overview
 
-Chrome Extension (Manifest V3) that collects and tracks DanceDanceRevolution scores from the DDR World official website. Built with Vue 3, webpack, and Jest.
+Chrome Extension (Manifest V3) that collects and tracks DanceDanceRevolution scores from the DDR World official website. Built with **TypeScript**, Vue 3, webpack, and Jest.
 
-- **Version**: 0.6.2
-- **Node requirement**: >=18.12.0
+- **Version**: `package.json` の `version` を参照（ここには書かない。リリースのたびに陳腐化するため）
+- **Node requirement**: >=24.0.0 (`package.json` の `engines`)
+- **Package manager**: Yarn 4.x (Berry)
 
 ## Commands
 
 ```bash
-yarn build:dev          # Development build (webpack, NODE_ENV=development)
-yarn build              # Production build (includes NODE_OPTIONS=--openssl-legacy-provider + clean)
+yarn build:dev          # Development build (tsc --noEmit + webpack, NODE_ENV=development)
+yarn build              # Production build (clean + tsc --noEmit + webpack。NODE_OPTIONS=--openssl-legacy-provider 付き)
 yarn test               # Run Jest tests
-yarn test -- --testPathPattern=Parser   # Run specific test file
+yarn test Parser        # Run specific test file (位置引数。最も簡潔)
+yarn test --updateSnapshot   # Update Jest snapshots
+yarn test:e2e           # Playwright E2E（現在は全件失敗する → #692）
 yarn lint               # ESLint (flat config)
-yarn prettier:write     # Format all src/**/*.{js,vue,json,html} and test/**/*.js
+yarn prettier           # 整形結果を stdout に出すだけ (チェックでも書き換えでもない)
+yarn prettier:write     # Format src/**/*.{js,vue,json,html} and test/**/*.js
+yarn package            # 配布用 zip を作成 (scripts/packageExtension.mjs)
+yarn update-difficulties        # BEMANIWiki から難易度データを更新
+yarn update-contained-version   # BEMANIWiki から収録バージョンを更新
 yarn clean              # Remove dist/
 ```
+
+> **`yarn test` に `--` を付けないこと**: Yarn Berry では `--` がそのまま jest に渡され、
+> テストパスパターンとして解釈される（`Pattern: --updateSnapshot - 0 matches` となり
+> **オプションが無視されたまま成功したように見える**）。
+> `yarn test -- --updateSnapshot` はスナップショットを更新しない。
+
+> **`--testPathPattern` は使えない**: jest 30 で `--testPathPatterns`（複数形）に改名された。
+> 旧名を渡すと 0 件マッチで終わる。位置引数の `yarn test Parser` を使うのが安全。
 
 > Always use `yarn build` (not direct webpack) — the script sets `NODE_OPTIONS=--openssl-legacy-provider` required for the build.
 
@@ -27,27 +42,36 @@ yarn clean              # Remove dist/
 
 ```
 Vue (browser_action UI)
-  → App.js          (orchestrates all operations)
-  → BrowserController.js  (tab/messaging abstraction)
+  → App.ts          (orchestrates all operations)
+  → BrowserController.ts  (tab/messaging abstraction)
   → ContentScript         (injected into DDR World pages)
-  → Parser.js       (parses HTML into structured data)
-  → Storage.js      (chrome.storage.local CRUD)
+  → Parser.ts       (parses HTML into structured data)
+  → Storage.ts      (chrome.storage.local CRUD)
   → Vue             (re-renders updated state)
 ```
+
+`src/` はほぼ全面 TypeScript 化済み。UI コンポーネントのみ `.vue`。
+JavaScript のまま残っているのは `src/static/common/i18n4html.js` /
+`src/options_ui/index.js` / `src/static/browser_action/debug/browser-controller.js` の 3 ファイルのみ。
 
 ## Key Files
 
 | File | Path |
 |------|------|
-| App.js | `src/static/common/App.js` |
-| Parser.js | `src/static/common/Parser.js` |
-| Constants.js | `src/static/common/Constants.js` |
-| Storage.js | `src/static/common/Storage.js` |
-| BrowserController.js | `src/static/common/BrowserController.js` |
+| App.ts | `src/static/common/App.ts` |
+| Parser.ts | `src/static/common/Parser.ts` |
+| Constants.ts | `src/static/common/Constants.ts` |
+| Storage.ts | `src/static/common/Storage.ts` |
+| BrowserController.ts | `src/static/common/BrowserController.ts` |
+| manifest | `src/manifest.json` |
 | i18n (en) | `src/static/_locales/en/messages.json` |
 | i18n (ja) | `src/static/_locales/ja/messages.json` |
-| Tests | `test/` |
-| Fixture HTML | `test/` (HTML snapshots for Parser tests) |
+| Unit tests | `test/` |
+| Fixture HTML | `test/common/Parser/fixtures/`, `test/scripts/fixtures/` |
+| E2E tests | `test-e2e/` (Playwright) |
+| CI | `.github/workflows/ci.yml` |
+| Yarn 設定 | `.yarnrc.yml` |
+| Dependabot 設定 | `.github/dependabot.yml` |
 
 ## Coding Conventions
 
@@ -57,14 +81,23 @@ Vue (browser_action UI)
 - **Prettier**: single quotes, print width 180, trailing commas (ES5)
 - **No npm** — always use `yarn`
 
-## Game Domain Constants (src/static/common/Constants.js)
+> **`.ts` は自動整形されない**: `yarn prettier:write` の glob（`src/**/*.{js,vue,json,html}` と
+> `test/**/*.js`）に `.ts` が含まれておらず、`eslint.config.mjs` も prettier プラグインを
+> 有効にしていない。lint-staged も同じ glob。`.ts` を編集したときは手で整形規約に合わせること。
 
-```javascript
+## Game Domain Constants (src/static/common/Constants.ts)
+
+すべて `Constants` クラスの static getter。
+
+```typescript
 GAME_VERSION: { A20PLUS: 0, A3: 1, WORLD: 2 }
 
 PLAY_MODE: { SINGLE: 0, DOUBLE: 1 }
 
-DIFFICULTY: { BEGINNER: 0, BASIC: 1, DIFFICULT: 2, EXPERT: 3, CHALLENGE: 4 }
+MUSIC_TYPE: { UNKNOWN: -1, NORMAL: 0, NONSTOP: 1, GRADE: 2, GRADE_PLUS: 3, GRADE_A3: 4 }
+
+// 名前は複数形の DIFFICULTIES。DIFFICULTY ではない
+DIFFICULTIES: { BEGINNER: 0, BASIC: 1, DIFFICULT: 2, EXPERT: 3, CHALLENGE: 4 }
 
 CLEAR_TYPE: {
   NO_PLAY: 0, FAILED: 1, ASSIST_CLEAR: 2, CLEAR: 3, LIFE4: 4,
@@ -78,20 +111,48 @@ SCORE_RANK: {
   A_MINUS: 10, A: 11, A_PLUS: 12,
   AA_MINUS: 13, AA: 14, AA_PLUS: 15, AAA: 16
 }
+
+FLARE_RANK: { NONE: 0, FLARE_1: 1, ... FLARE_9: 9, FLARE_EX: 10 }
 ```
+
+`MUSIC_VERSION`（DDR シリーズの初収録バージョン）は `GAME_VERSION`（eagate の対象シリーズ）とは
+別概念。値を追加した場合は `MusicVersion` 型と `scripts/musicVersionMap.cjs` も合わせて更新すること。
 
 ## manifest.json 設計メモ
 
 - `unlimitedStorage`: MV3 では非推奨だが意図的に残している。スコア・楽曲リスト・差分履歴の蓄積により chrome.storage.local のデフォルト上限 10MB を超えるリスクがあるため。
 - `http://skillattack.com/`: skillattack.com が HTTPS 非対応のため http のまま。
+- `version` は `null`。ビルド時に `package.json` から注入する。
+
+## 依存関係の運用方針
+
+「常に 14 日遅れの最新を取る」。サプライチェーン攻撃対策として、公開直後のバージョンは取り込まない。
+
+| 設定 | 役割 |
+|---|---|
+| `.yarnrc.yml` の `npmMinimalAgeGate: 14d` | install 時の強制力。手動の `yarn up` や security update PR にも効く |
+| `.github/dependabot.yml` の `cooldown: 14` | version update PR を作らせないための入口側の制御 |
+
+**両者の値は必ず揃えること。** 揃っていないと、Dependabot が作った PR が
+`npmMinimalAgeGate` に弾かれて `yarn install` に失敗する。
+
+緊急 CVE 等で 14 日待てない場合のみ `.yarnrc.yml` の `npmPreapprovedPackages` に例外を追加し、
+解禁日を過ぎたら削除する別 PR を作ること。
+
+## CI (.github/workflows/ci.yml)
+
+PR と master への push で `yarn install --immutable` → `lint` → `tsc --noEmit` → `test` → `build` を実行。
+E2E は全件失敗中のため CI に含めていない（#692）。
 
 ## Critical Rules
 
 1. **i18n**: When adding any user-visible string, update **both** `en/messages.json` and `ja/messages.json`.
 
-2. **Parser.js snapshots**: Changes to `Parser.js` will affect snapshot tests. Run `yarn test` and review any updated snapshots before committing.
+2. **Parser.ts snapshots**: Changes to `Parser.ts` will affect snapshot tests. Run `yarn test` and review any updated snapshots before committing.
 
-3. **Chrome Extension constraints**:
+3. **依存更新の 14 日ゲート**: `.yarnrc.yml` の `npmMinimalAgeGate` と `.github/dependabot.yml` の `cooldown` は必ず同じ値に保つこと。
+
+4. **Chrome Extension constraints**:
    - Cannot use `fetch` or XHR directly from content scripts in all contexts
    - Use `chrome.storage.local` (not localStorage) for persistence
    - Background runs as a Service Worker (no DOM access, limited lifetime)
@@ -99,8 +160,9 @@ SCORE_RANK: {
 
 ## Testing
 
-- **Framework**: Jest 29
+- **Framework**: Jest 30（ユニット）/ Playwright（E2E）
 - **Snapshot tests**: Parser output is snapshot-tested against fixture HTML files
-- **Run single test**: `yarn test -- --testPathPattern=Parser`
-- **Update snapshots**: `yarn test -- --updateSnapshot`
-- Fixture HTML files live in `test/` directory alongside test files
+- **Run single test**: `yarn test Parser`（`--` を付けない。上の Commands の注記を参照）
+- **Update snapshots**: `yarn test --updateSnapshot`
+- Unit tests live in `test/`; fixture HTML files live in the `fixtures/` directory alongside each test
+- E2E tests live in `test-e2e/`（現在は全件失敗する → #692）


### PR DESCRIPTION
Closes #700

`CLAUDE.md` の記述がリポジトリの実態と乖離していたため修正する。

## 1. 動作しないテストコマンドの修正（実害あり）

実際に実行して確認した。

| コマンド | 結果 |
|---|---|
| `yarn test -- --testPathPattern=Parser` | `Pattern: --testPathPattern=Parser - 0 matches` |
| `yarn test Parser` | 8 suites / 74 tests / 41 snapshots ✅ |
| `yarn test --testPathPatterns=Parser` | 同上 ✅ |

原因は 2 つ重なっている。

1. Yarn Berry では `--` がそのまま jest に渡され、テストパスパターンとして解釈される
2. jest 30 で `--testPathPattern` は `--testPathPatterns`（複数形）に改名された

特に `yarn test -- --updateSnapshot` は**スナップショットを更新しないまま成功したように見える**ため、
位置引数 `yarn test Parser` を推奨として記載し、理由を注記した。

## 2〜5. その他の乖離

- Key Files テーブルと Architecture 図のパスを `.js` → `.ts` に
- Node requirement を `>=24.0.0` に（#693）
- 未記載だったスクリプトを追記（`test:e2e` / `package` / `update-difficulties` / `update-contained-version` / `prettier`）
- 未記載だった構成要素を追記（`.github/workflows/ci.yml` / `test-e2e/` / `.yarnrc.yml` / `.github/dependabot.yml`）
- `.yarnrc.yml` の `npmMinimalAgeGate` と dependabot の `cooldown` を揃える「常に 14 日遅れの最新を取る」方針を専用セクションに明文化し、Critical Rules にも追加

## 6. Version 表記

削除して `package.json` を参照させる形にした（リリースのたびに手で追従する必要をなくすため）。

## 調査中に追加で見つかった乖離

issue には挙がっていなかったが、確認の過程で見つかったもの。

- **ドメイン定数名が誤っていた**: `DIFFICULTY` と書かれていたが、実際は `Constants.DIFFICULTIES`（複数形）。`App.ts:565` などで使われている名前と食い違っていた。あわせて未記載だった `MUSIC_TYPE` / `FLARE_RANK` を追記
- **`yarn prettier` はチェックではない**: `--check` が付いておらず、整形結果を stdout に流すだけだった。issue 本文の「フォーマットチェック」という記載も実態と異なる
- **`.ts` が自動整形されない**: `prettier:write` の glob（`src/**/*.{js,vue,json,html}`）に `.ts` が含まれず、`eslint.config.mjs` も prettier プラグインを有効にしていない。lint-staged も同じ glob。本 PR では CLAUDE.md への注記のみに留めた（設定側を直すかは別途判断が必要）

## メモリ側の整理

issue の「`.claude/` 配下のメモリ類も確認するとよい」の指摘どおり、Claude Code の
プロジェクトメモリに壊れたテストコマンドと `.js` パスがそのまま複製されていた。
CLAUDE.md との二重管理が陳腐化の原因なので、重複部分を削除して CLAUDE.md を参照させる形にした。
（メモリはリポジトリ外のため本 PR の差分には含まれない）

## 確認

- `yarn lint` → exit 0
- `yarn test` → 54 suites / 578 tests / 41 snapshots 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)