### PR TITLE
build: TypeScript ファイルを prettier の整形対象に含める

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
+      - name: Format check
+        run: yarn prettier:check
+
       - name: Lint
         run: yarn lint
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,8 @@ yarn test --updateSnapshot   # Update Jest snapshots
 yarn test:e2e           # Playwright E2E（現在は全件失敗する → #692）
 yarn lint               # ESLint (flat config)
 yarn prettier           # 整形結果を stdout に出すだけ (チェックでも書き換えでもない)
-yarn prettier:write     # Format src/**/*.{js,vue,json,html} and test/**/*.js
+yarn prettier:write     # Format src/**/*.{js,ts,vue,json,html} and test/**/*.js
+yarn prettier:check     # 整形されているかを検査するだけ (CI が実行する)
 yarn package            # 配布用 zip を作成 (scripts/packageExtension.mjs)
 yarn update-difficulties        # BEMANIWiki から難易度データを更新
 yarn update-contained-version   # BEMANIWiki から収録バージョンを更新
@@ -81,10 +82,10 @@ JavaScript のまま残っているのは `src/static/common/i18n4html.js` /
 - **Prettier**: single quotes, print width 180, trailing commas (ES5)
 - **No npm** — always use `yarn`
 
-> **`.ts` は自動整形されない**: `yarn prettier:write` の glob（`src/**/*.{js,vue,json,html}` と
-> `test/**/*.js`）に `.ts` が含まれておらず、`eslint.config.mjs` も prettier プラグインを
-> 有効にしていない。lint-staged も同じ glob。`.ts` を編集したときは手で整形規約に合わせること
-> （→ #711）。
+> **整形は prettier、lint は eslint と役割を分ける**: `eslint.config.mjs` に整形系のルールは
+> 入れない（`eslint-plugin-prettier` / `eslint-config-prettier` は使わないので devDependencies
+> にも入っていない）。整形は `yarn prettier:write` と lint-staged が担当し、CI は
+> `yarn prettier:check` で検査する。glob は `src/**/*.{js,ts,vue,json,html}` と `test/**/*.js`。
 
 ## Game Domain Constants (src/static/common/Constants.ts)
 
@@ -142,7 +143,7 @@ FLARE_RANK: { NONE: 0, FLARE_1: 1, ... FLARE_9: 9, FLARE_EX: 10 }
 
 ## CI (.github/workflows/ci.yml)
 
-PR と master への push で `yarn install --immutable` → `lint` → `tsc --noEmit` → `test` → `build` を実行。
+PR と master への push で `yarn install --immutable` → `prettier:check` → `lint` → `tsc --noEmit` → `test` → `build` を実行。
 E2E は全件失敗中のため CI に含めていない（#692）。
 
 ## Critical Rules

--- a/package.json
+++ b/package.json
@@ -24,8 +24,6 @@
     "cross-env": "10.1.0",
     "css-loader": "7.1.4",
     "eslint": "10.7.0",
-    "eslint-config-prettier": "10.1.8",
-    "eslint-plugin-prettier": "5.5.6",
     "eslint-plugin-vue": "10.10.0",
     "globals": "17.7.0",
     "husky": "9.1.7",
@@ -49,8 +47,9 @@
   "scripts": {
     "clean": "rm -rf dist",
     "lint": "ESLINT_USE_FLAT_CONFIG=true eslint -c eslint.config.mjs",
-    "prettier": "prettier \"src/**/*.{js,vue,json,html}\" \"test/**/*.js\"",
+    "prettier": "prettier \"src/**/*.{js,ts,vue,json,html}\" \"test/**/*.js\"",
     "prettier:write": "yarn prettier --write",
+    "prettier:check": "yarn prettier --check",
     "build": "yarn clean && cross-env NODE_OPTIONS=--openssl-legacy-provider tsc --noEmit && cross-env NODE_OPTIONS=--openssl-legacy-provider NODE_ENV=production webpack",
     "build:dev": "tsc --noEmit && cross-env NODE_ENV=development webpack",
     "update-difficulties": "node --import './scripts/_ts-register.mjs' scripts/updateDifficultiesFromBemaniwiki.mjs",
@@ -61,7 +60,7 @@
     "prepare": "husky"
   },
   "lint-staged": {
-    "src/**/*.{js,vue}": [
+    "src/**/*.{js,ts,vue}": [
       "prettier --write",
       "eslint --fix"
     ],

--- a/src/browser_action/filter.ts
+++ b/src/browser_action/filter.ts
@@ -76,9 +76,11 @@ export function initialize(a: App) {
   /* All, Noneのイベントハンドラをつける */
   document.getElementById('summarySetting_all')!.addEventListener('click', selectAll.bind(null, 'summarySetting'));
   document.getElementById('summarySetting_clear')!.addEventListener('click', selectNone.bind(null, 'summarySetting'));
-  filterNames.filter((name) => name !== 'playMode').forEach((name) => {
-    document.getElementById(`filterCondition_${name}_clear`)!.addEventListener('click', selectNone.bind(null, `filterCondition_${name}`));
-  });
+  filterNames
+    .filter((name) => name !== 'playMode')
+    .forEach((name) => {
+      document.getElementById(`filterCondition_${name}_clear`)!.addEventListener('click', selectNone.bind(null, `filterCondition_${name}`));
+    });
   document.getElementById('filterCondition_containedVersion_classic')!.addEventListener('click', selectRange.bind(null, 'filterCondition_containedVersion', 0, 12));
   document.getElementById('filterCondition_containedVersion_white')!.addEventListener('click', selectRange.bind(null, 'filterCondition_containedVersion', 13, 15));
   document.getElementById('filterCondition_containedVersion_gold')!.addEventListener('click', selectRange.bind(null, 'filterCondition_containedVersion', 16, 19));

--- a/src/browser_action/menu.ts
+++ b/src/browser_action/menu.ts
@@ -50,7 +50,7 @@ document.getElementById('exportScoreToSkillAttackButton')!.addEventListener('cli
   app
     .exportScoreToSkillAttack(
       (document.getElementById('exportScoreToSkillAttackDdrCode') as HTMLInputElement).value,
-      (document.getElementById('exportScoreToSkillAttackPassword') as HTMLInputElement).value,
+      (document.getElementById('exportScoreToSkillAttackPassword') as HTMLInputElement).value
     )
     .then((value) => {
       Logger.debug(`exportScoreToSkillAttack success : ${value}`);

--- a/src/static/common/App.ts
+++ b/src/static/common/App.ts
@@ -331,8 +331,7 @@ export class App {
     Logger.info(I18n.getMessage('log_message_refresh_all_music_info_begin'));
     this.dataFetchController.targetGameVersion = gameVersion;
     this.dataFetchController.targetMusics = [];
-    this.musicList!.musicIds
-      .sort()
+    this.musicList!.musicIds.sort()
       .filter((musicId) => {
         return musicId >= musicIdForFilter;
       })
@@ -357,7 +356,9 @@ export class App {
     this.changeState(STATE.UPDATE_MUSIC_DETAIL);
     try {
       this.dataFetchController.targetMusic = this.dataFetchController.targetMusics.shift()!;
-      Logger.info(I18n.getMessage('log_message_fetch_missing_music_info_progress', [this.dataFetchController.targetMusic.musicId, String(this.dataFetchController.targetMusics.length)]));
+      Logger.info(
+        I18n.getMessage('log_message_fetch_missing_music_info_progress', [this.dataFetchController.targetMusic.musicId, String(this.dataFetchController.targetMusics.length)])
+      );
       await this.browserController.createTab(this.dataFetchController.targetMusic.url, this.options!['openTabAsActive'] as boolean);
     } catch (error) {
       this.browserController.reset();
@@ -410,7 +411,9 @@ export class App {
     this.changeState(STATE.UPDATE_MUSIC_DETAIL);
     try {
       this.dataFetchController.targetMusic = this.dataFetchController.targetMusics.shift()!;
-      Logger.info(I18n.getMessage('log_message_fetch_missing_music_info_progress', [this.dataFetchController.targetMusic.musicId, String(this.dataFetchController.targetMusics.length)]));
+      Logger.info(
+        I18n.getMessage('log_message_fetch_missing_music_info_progress', [this.dataFetchController.targetMusic.musicId, String(this.dataFetchController.targetMusics.length)])
+      );
       await this.browserController.createTab(this.dataFetchController.targetMusic.url, this.options!['openTabAsActive'] as boolean);
     } catch (error) {
       this.browserController.reset();
@@ -627,9 +630,7 @@ export class App {
         );
         break;
       case STATE.UPDATE_RIVAL_MUSIC_LIST:
-        this.browserController.sendMessageToTab({ type: 'PARSE_RIVAL_MUSIC_LIST' }, (res) =>
-          this.dataFetchController.handleRivalMusicListResponse(res as ParseResponse)
-        );
+        this.browserController.sendMessageToTab({ type: 'PARSE_RIVAL_MUSIC_LIST' }, (res) => this.dataFetchController.handleRivalMusicListResponse(res as ParseResponse));
         break;
       default:
         Logger.debug('onUpdateTab: event was ignored.');

--- a/src/static/common/DataFetchController.ts
+++ b/src/static/common/DataFetchController.ts
@@ -197,13 +197,7 @@ export class DataFetchController {
       await this.onNavigateTo(res.nextUrl!);
     } else if (this.targetPlayMode === Constants.PLAY_MODE.SINGLE) {
       this.targetPlayMode = Constants.PLAY_MODE.DOUBLE as PlayMode;
-      Logger.info(
-        I18n.getMessage('log_message_update_rival_music_list_progress', [
-          I18n.getMessage(`log_message_update_score_list_play_mode_${this.targetPlayMode}`),
-          '1',
-          '?',
-        ])
-      );
+      Logger.info(I18n.getMessage('log_message_update_rival_music_list_progress', [I18n.getMessage(`log_message_update_score_list_play_mode_${this.targetPlayMode}`), '1', '?']));
       await this.onNavigateTo(Constants.RIVAL_MUSIC_DATA_URL[Constants.GAME_VERSION.WORLD][this.targetPlayMode].replace('[rivalId]', this.targetRivalId!));
     } else {
       await this.onFinishAction();

--- a/src/static/common/SkillAttackDataList.ts
+++ b/src/static/common/SkillAttackDataList.ts
@@ -82,7 +82,14 @@ export class SkillAttackDataList {
         const clearType = clearTypeValue > 5 ? clearTypeValue - 5 : clearTypeValue === 5 ? 1 : 0;
         const musicTitle = musicList.hasMusic(musicId) ? musicList.getMusicDataById(musicId).title : '???';
         const difficultyString = Constants.PLAY_MODE_AND_DIFFICULTY_STRING[Number(difficultyValue)];
-        const data = new SkillAttackDataElement(index, Util.getPlayMode(Number(difficultyValue) as import('./Constants.js').DifficultyValue), Util.getDifficulty(Number(difficultyValue) as import('./Constants.js').DifficultyValue), 0, score as number, clearType as number);
+        const data = new SkillAttackDataElement(
+          index,
+          Util.getPlayMode(Number(difficultyValue) as import('./Constants.js').DifficultyValue),
+          Util.getDifficulty(Number(difficultyValue) as import('./Constants.js').DifficultyValue),
+          0,
+          score as number,
+          clearType as number
+        );
         if (currentData !== null) {
           // 更新チェック
           if ((score as number) > currentData.score || (clearType as number) > currentData.clearType) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2145,13 +2145,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pkgr/core@npm:^0.3.6":
-  version: 0.3.6
-  resolution: "@pkgr/core@npm:0.3.6"
-  checksum: 10c0/153f0f4563f505faeba13c733efa0e05e467ce1c6b941055a5fd3b4560da60fbf1dff4b11da0075f034ddda11f2842b90395f60895dde5825875b616edccc11c
-  languageName: node
-  linkType: hard
-
 "@playwright/test@npm:1.61.1":
   version: 1.61.1
   resolution: "@playwright/test@npm:1.61.1"
@@ -3117,8 +3110,6 @@ __metadata:
     cross-env: "npm:10.1.0"
     css-loader: "npm:7.1.4"
     eslint: "npm:10.7.0"
-    eslint-config-prettier: "npm:10.1.8"
-    eslint-plugin-prettier: "npm:5.5.6"
     eslint-plugin-vue: "npm:10.10.0"
     globals: "npm:17.7.0"
     husky: "npm:9.1.7"
@@ -4021,37 +4012,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-config-prettier@npm:10.1.8":
-  version: 10.1.8
-  resolution: "eslint-config-prettier@npm:10.1.8"
-  peerDependencies:
-    eslint: ">=7.0.0"
-  bin:
-    eslint-config-prettier: bin/cli.js
-  checksum: 10c0/e1bcfadc9eccd526c240056b1e59c5cd26544fe59feb85f38f4f1f116caed96aea0b3b87868e68b3099e55caaac3f2e5b9f58110f85db893e83a332751192682
-  languageName: node
-  linkType: hard
-
-"eslint-plugin-prettier@npm:5.5.6":
-  version: 5.5.6
-  resolution: "eslint-plugin-prettier@npm:5.5.6"
-  dependencies:
-    prettier-linter-helpers: "npm:^1.0.1"
-    synckit: "npm:^0.11.13"
-  peerDependencies:
-    "@types/eslint": ">=8.0.0"
-    eslint: ">=8.0.0"
-    eslint-config-prettier: ">= 7.0.0 <10.0.0 || >=10.1.0"
-    prettier: ">=3.0.0"
-  peerDependenciesMeta:
-    "@types/eslint":
-      optional: true
-    eslint-config-prettier:
-      optional: true
-  checksum: 10c0/af37126c947ff3e87ff1ea76408db8cb1c7da966ebdaba68c6dd5924da7eb1b43b1abc4796d753a97b1bc26ea94c5497093e6ab9f8588fffe558d5a554e19bbf
-  languageName: node
-  linkType: hard
-
 "eslint-plugin-vue@npm:10.10.0":
   version: 10.10.0
   resolution: "eslint-plugin-vue@npm:10.10.0"
@@ -4280,13 +4240,6 @@ __metadata:
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
   checksum: 10c0/40dedc862eb8992c54579c66d914635afbec43350afbbe991235fdcb4e3a8d5af1b23ae7e79bef7d4882d0ecee06c3197488026998fb19f72dc95acff1d1b1d0
-  languageName: node
-  linkType: hard
-
-"fast-diff@npm:^1.1.2":
-  version: 1.3.0
-  resolution: "fast-diff@npm:1.3.0"
-  checksum: 10c0/5c19af237edb5d5effda008c891a18a585f74bf12953be57923f17a3a4d0979565fc64dbc73b9e20926b9d895f5b690c618cbb969af0cf022e3222471220ad29
   languageName: node
   linkType: hard
 
@@ -6352,15 +6305,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier-linter-helpers@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "prettier-linter-helpers@npm:1.0.1"
-  dependencies:
-    fast-diff: "npm:^1.1.2"
-  checksum: 10c0/91cea965681bc5f62c9d26bd3ca6358b81557261d4802e96ec1cf0acbd99d4b61632d53320cd2c3ec7d7f7805a81345644108a41ef46ddc9688e783a9ac792d1
-  languageName: node
-  linkType: hard
-
 "prettier@npm:3.9.6":
   version: 3.9.6
   resolution: "prettier@npm:3.9.6"
@@ -6825,15 +6769,6 @@ __metadata:
   version: 3.2.4
   resolution: "symbol-tree@npm:3.2.4"
   checksum: 10c0/dfbe201ae09ac6053d163578778c53aa860a784147ecf95705de0cd23f42c851e1be7889241495e95c37cabb058edb1052f141387bef68f705afc8f9dd358509
-  languageName: node
-  linkType: hard
-
-"synckit@npm:^0.11.13":
-  version: 0.11.13
-  resolution: "synckit@npm:0.11.13"
-  dependencies:
-    "@pkgr/core": "npm:^0.3.6"
-  checksum: 10c0/5a6c19f4f79045aaa7994106401bff6dbe7cca23a6d0a0723ff14eb8b1bebeb4a71729118f6914905598e304ea2fa13509885e11ba07d92e7cb68a06740cb328
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #711

`src/` は TypeScript 移行済みだが `.ts` を整形する経路が 1 つも存在せず、実際に 5 ファイルが規約から外れていた。整形経路を用意し、既存のドリフトを解消する。

## 変更内容

コミットは 2 つに分けている。**1 つ目は整形のみで挙動の変更を含まない**ため、レビューは 2 つ目を中心に見てほしい。

### `style: .ts に prettier を適用する` (bc36d20)

規約 (`printWidth: 180` / `trailingComma: "es5"`) から外れていた 5 ファイルに `prettier --write` を適用。整形のみ。

- `src/browser_action/filter.ts`
- `src/browser_action/menu.ts`
- `src/static/common/App.ts`
- `src/static/common/DataFetchController.ts`
- `src/static/common/SkillAttackDataList.ts`

### `build: .ts を prettier の対象に含め、CI で整形を検査する` (5b7189d)

- `prettier` スクリプトの glob に `ts` を追加 (`src/**/*.{js,ts,vue,json,html}`)
- lint-staged の glob にも `ts` を追加
- `prettier:check` を新設し、CI の Lint ステップ前に実行する
  - 既存の `yarn prettier` は `--check` が付いておらず、整形結果を stdout に流すだけでチェックとして機能しないため別スクリプトにした
- `eslint-plugin-prettier` / `eslint-config-prettier` を devDependencies から削除
  - flat config のどのブロックからも参照されていなかった。整形は prettier、lint は eslint と役割を分ける方針とする (prettier 公式も `eslint-plugin-prettier` を非推奨としている)
- `CLAUDE.md` の「`.ts` は自動整形されない」という注記を、新しい方針の説明に差し替え。Commands と CI の記述も更新

## 検証

ローカルで以下すべて成功。

- `yarn prettier:check`
- `yarn lint`
- `yarn tsc --noEmit`
- `yarn test` (54 suites / 578 tests / 41 snapshots すべて pass)
- `yarn build`

また 1 つ目のコミット時に lint-staged が `src/**/*.{js,ts,vue}` で `.ts` を拾って発火することを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)