### PR TITLE
ci: E2E (Playwright) を CI で実行する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,46 @@ jobs:
       - name: Build
         run: yarn build
 
-  # E2E (Playwright) は現在すべて失敗するため CI に含めていない。
-  # 修復後にジョブを追加すること。
-  # https://github.com/ryowatanabe/DDRScoreTracker/issues/692
+  # E2E は他のチェックと壊れ方の性質が違う (flaky になり得る) ため、
+  # verify とは別ジョブにして並列に実行する。dist は自前で用意する。
+  e2e:
+    name: E2E (Playwright)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      # runner イメージには Chromium 実行に必要な共有ライブラリが揃っていないため
+      # --with-deps が必要。MV3 の Service Worker 検出には chromium 本体が要るので
+      # chrome-headless-shell だけでは足りない。
+      - name: Install Playwright browsers
+        run: yarn playwright install --with-deps chromium
+
+      # E2E は development ビルドの dist/ を読み込む
+      - name: Build extension
+        run: yarn build:dev
+
+      - name: Run E2E tests
+        run: yarn test:e2e
+
+      # 失敗時のみ trace (retries: 1 + trace: on-first-retry で生成される) を残す
+      - name: Upload Playwright artifacts
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-results
+          path: test-results/
+          retention-days: 7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ yarn build              # Production build (clean + tsc --noEmit + webpack。NOD
 yarn test               # Run Jest tests
 yarn test Parser        # Run specific test file (位置引数。最も簡潔)
 yarn test --updateSnapshot   # Update Jest snapshots
-yarn test:e2e           # Playwright E2E（現在は全件失敗する → #692）
+yarn test:e2e           # Playwright E2E（要 `yarn build:dev`。ブラウザは自動で用意される）
 yarn lint               # ESLint (flat config)
 yarn prettier           # 整形結果を stdout に出すだけ (チェックでも書き換えでもない)
 yarn prettier:write     # Format src/**/*.{js,ts,vue,json,html} and test/**/*.js
@@ -143,8 +143,12 @@ FLARE_RANK: { NONE: 0, FLARE_1: 1, ... FLARE_9: 9, FLARE_EX: 10 }
 
 ## CI (.github/workflows/ci.yml)
 
-PR と master への push で `yarn install --immutable` → `prettier:check` → `lint` → `tsc --noEmit` → `test` → `build` を実行。
-E2E は全件失敗中のため CI に含めていない（#692）。
+PR と master への push で 2 ジョブを並列実行する。
+
+| ジョブ | 内容 |
+|---|---|
+| `verify` | `yarn install --immutable` → `prettier:check` → `lint` → `tsc --noEmit` → `test` → `build` |
+| `e2e` | `playwright install --with-deps chromium` → `build:dev` → `test:e2e`。失敗時のみ `test-results/`（trace）を artifact に残す |
 
 ## Critical Rules
 
@@ -167,4 +171,8 @@ E2E は全件失敗中のため CI に含めていない（#692）。
 - **Run single test**: `yarn test Parser`（`--` を付けない。上の Commands の注記を参照）
 - **Update snapshots**: `yarn test --updateSnapshot`
 - Unit tests live in `test/`; fixture HTML files live in the `fixtures/` directory alongside each test
-- E2E tests live in `test-e2e/`（現在は全件失敗する → #692）
+- E2E tests live in `test-e2e/`。`yarn build:dev` で `dist/` を作ってから `yarn test:e2e`
+- **E2E のブラウザ起動方法は変えないこと**: MV3 の Service Worker は `channel: 'chromium'`
+  （＝chromium 本体）でないと検出できず、chrome-headless-shell では取得できない。
+  生の `--headless` / `--headless=new` を引数で渡すのも禁止（Chrome 側の実装変更で
+  起動ごとクラッシュした前例がある → #692）。目視したいときは `HEADED=1 yarn test:e2e`

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "update-contained-version": "node --import './scripts/_ts-register.mjs' scripts/updateContainedVersionFromBemaniwiki.mjs",
     "package": "node scripts/packageExtension.mjs",
     "test": "jest",
-    "test:e2e": "playwright test",
+    "test:e2e": "playwright install chromium && playwright test",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/test-e2e/extension.spec.js
+++ b/test-e2e/extension.spec.js
@@ -19,28 +19,32 @@
  */
 
 const { chromium, test, expect } = require('@playwright/test');
+const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 const pathToExtension = path.join(__dirname, '..', 'dist');
 
 /**
  * Launch a persistent Chromium context with the extension loaded.
- * Returns { context, extensionId }.
+ * Returns { context, userDataDir, extensionId }.
+ *
+ * MV3 の Service Worker を検出するには chromium 本体が必要で、
+ * headless の既定である chrome-headless-shell では検出できない。
+ * channel: 'chromium' が本体を選ばせる（生の --headless* 引数は渡さないこと。
+ * Chrome 側の headless 実装変更に巻き込まれて起動ごと落ちた前例がある → #692）。
+ *
+ * ローカルで目視したい場合は HEADED=1 yarn test:e2e。
  */
 async function launchExtensionContext() {
-  const userDataDir = path.join(__dirname, '..', '.playwright-user-data');
-  const isCI = !!process.env.CI;
+  // プロファイルを使い回すと chrome.storage.local が実行を跨いで残り、
+  // まっさらな CI と状態が食い違うため、起動ごとに捨てる
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ddrst-e2e-'));
 
   const context = await chromium.launchPersistentContext(userDataDir, {
-    headless: false,
-    args: [
-      `--disable-extensions-except=${pathToExtension}`,
-      `--load-extension=${pathToExtension}`,
-      // Use new headless mode for CI (supports extensions unlike old headless)
-      ...(isCI ? ['--headless=new'] : []),
-      '--no-sandbox',
-      '--disable-setuid-sandbox',
-    ],
+    headless: process.env.HEADED !== '1',
+    channel: 'chromium',
+    args: [`--disable-extensions-except=${pathToExtension}`, `--load-extension=${pathToExtension}`, '--no-sandbox', '--disable-setuid-sandbox'],
   });
 
   // Wait for the service worker to start and get the extension ID
@@ -50,19 +54,28 @@ async function launchExtensionContext() {
   }
 
   const extensionId = background.url().split('/')[2];
-  return { context, extensionId };
+  return { context, userDataDir, extensionId };
+}
+
+/**
+ * Close the context and remove its throwaway user data directory.
+ */
+async function closeExtensionContext(context, userDataDir) {
+  await context.close();
+  fs.rmSync(userDataDir, { recursive: true, force: true });
 }
 
 test.describe('Chrome Extension: 拡張機能ロード', () => {
   let context;
+  let userDataDir;
   let extensionId;
 
   test.beforeAll(async () => {
-    ({ context, extensionId } = await launchExtensionContext());
+    ({ context, userDataDir, extensionId } = await launchExtensionContext());
   });
 
   test.afterAll(async () => {
-    await context.close();
+    await closeExtensionContext(context, userDataDir);
   });
 
   test('Service Worker が起動し拡張機能 ID が取得できる', () => {
@@ -92,15 +105,16 @@ test.describe('Chrome Extension: 拡張機能ロード', () => {
 
 test.describe('Chrome Extension: browser_action UI', () => {
   let context;
+  let userDataDir;
   let extensionId;
   let page;
 
   test.beforeAll(async () => {
-    ({ context, extensionId } = await launchExtensionContext());
+    ({ context, userDataDir, extensionId } = await launchExtensionContext());
   });
 
   test.afterAll(async () => {
-    await context.close();
+    await closeExtensionContext(context, userDataDir);
   });
 
   test.beforeEach(async () => {
@@ -144,14 +158,15 @@ test.describe('Chrome Extension: browser_action UI', () => {
 
 test.describe('Chrome Extension: options_ui ページ', () => {
   let context;
+  let userDataDir;
   let extensionId;
 
   test.beforeAll(async () => {
-    ({ context, extensionId } = await launchExtensionContext());
+    ({ context, userDataDir, extensionId } = await launchExtensionContext());
   });
 
   test.afterAll(async () => {
-    await context.close();
+    await closeExtensionContext(context, userDataDir);
   });
 
   test('options ページが存在し表示される', async () => {


### PR DESCRIPTION
## 概要

#692 の E2E 全件失敗は、既にマージ済みの Playwright 1.58.2 → 1.61.1 更新（#PR: `76bc1ad`）によって**コード修正なしで解消済み**であることを検証で確認した。その上で、E2E を CI に載せ、再び同じ壊れ方をしないようにする。

## 検証結果

Playwright 1.61.1 / chromium-1228 / Node v24.14.0 / WSL2 で再検証した。

| 条件 | #692 記載時 (1.58.2 / chromium-1208) | 今回 (1.61.1 / chromium-1228) |
|---|---|---|
| `headless:false` + `--headless=new` | クラッシュ (SIGABRT) | 起動 OK / SW 検出 OK |
| `headless:false` + `--headless` | クラッシュ (SIGABRT) | 起動 OK / SW 検出 OK |
| `headless:true` + `channel:'chromium'` | クラッシュ | 起動 OK / SW 検出 OK |
| `headless:true`（引数・channel なし） | 起動 OK / SW 検出できず | 起動 OK / **SW 検出できず** |

最後の 1 行が唯一の失敗パターンで、これは chromium 本体ではなく chrome-headless-shell が使われるため。**MV3 の Service Worker 検出には chromium 本体が必要**という点だけが恒久的な制約で、`channel: 'chromium'` を指定すれば満たせる。

つまり #692 の「対応方針（案）」のうち、1（バージョン更新）は完了済み、2（headless テスト手法の再設計）は**不要**、残るのは 3（CI 追加）だけだった。

なお `yarn test:e2e` が今も落ちる状態だったのは #692 の症状ではなく、1.61.1 に上げた際に `playwright install` していなかったため（`Executable doesn't exist at …chromium-1228`）。

## 変更内容

- **`.github/workflows/ci.yml`**: `verify` と並列に走る `e2e` ジョブを追加。`playwright install --with-deps chromium` → `build:dev` → `test:e2e`。失敗時のみ `test-results/`（trace）を artifact に残す（7 日保持）
- **`test-e2e/extension.spec.js`**:
  - 起動を `channel: 'chromium'` + `headless` に統一し、`isCI` 分岐と生の `--headless=new` を削除。**ローカルと CI で起動経路が分かれており、CI 経路が誰にも実行されていなかったこと**が、壊れたまま気づかれなかった主因のため。目視したいときは `HEADED=1 yarn test:e2e`
  - `userDataDir` を起動ごとの一時ディレクトリ（`mkdtempSync`）に変更し、終了時に削除。固定プロファイルだと `chrome.storage.local` が実行を跨いで残り、まっさらな CI と状態が食い違う
- **`package.json`**: `test:e2e` に `playwright install chromium` を前置。Playwright 更新のたびに同じ踏み方をしないため（インストール済みなら即終了する）
- **`CLAUDE.md`**: 「E2E は全件失敗する（#692）」の記述を 3 箇所更新。加えて「起動方法を変えるな」の理由付き注意書きを追加

## 確認

- `CI=1 yarn test:e2e` → 7 passed
- `yarn test:e2e`（ローカル）→ 7 passed。一時ディレクトリの残留なし
- `yarn prettier:check` / `yarn lint` → パス

## 残課題（本 PR の範囲外）

現行 7 件のテストは `expect(locator('body')).toBeVisible()` や `innerHTML.length > 0` が大半で、実質「拡張がロードできる」以上のことを検証していない（`test-e2e/fixtures/test-data.js` も未使用）。テスト内容の刷新は別 issue を起票して対応する。

Closes #692

🤖 Generated with [Claude Code](https://claude.com/claude-code)