### PR TITLE
test(e2e): E2E テストを実際に意味のある検証に作り直す

### DIFF
--- a/test-e2e/extension.spec.js
+++ b/test-e2e/extension.spec.js
@@ -2,12 +2,14 @@
 /**
  * Playwright E2E tests for DDRScoreTracker Chrome Extension.
  *
- * These tests load the built extension into a real Chromium browser instance
- * and verify end-to-end behaviour including:
- *   - Extension loading and Service Worker registration
- *   - browser_action popup rendering
- *   - chrome.storage.local data injection and UI update
- *   - Filter and pagination interactions
+ * 検証対象は「実 Chrome + 実 chrome.* API + 実ビルド成果物でしか壊れ方が出ない部分」に絞る。
+ * 描画ロジックそのものは test/browser_action/*.test.js (jsdom + @vue/test-utils) が担保しており、
+ * そちらは I18n や Constants をモックに差し替えているため、実 API を通る経路は E2E でしか検証できない。
+ *
+ *   - chrome.storage.local の実データが popup に描画されること
+ *   - フィルタ操作が chrome.storage.local に永続化され、再読み込み後も復元されること
+ *   - chrome.i18n がロケールごとに _locales の文言を解決すること
+ *   - options_ui での設定変更が popup の挙動に効くこと
  *
  * Prerequisites:
  *   Run `yarn build:dev` before executing these tests.
@@ -15,7 +17,7 @@
  *
  * Usage:
  *   yarn test:e2e
- *   yarn build:dev && yarn test:e2e
+ *   HEADED=1 yarn test:e2e   (ブラウザを目視する場合)
  */
 
 const { chromium, test, expect } = require('@playwright/test');
@@ -23,20 +25,47 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
+const { createStorageFixture, SCORED_CHART, EXPECTED_SINGLE_CHARTS, EXPECTED_DOUBLE_CHARTS } = require('./fixtures/test-data.js');
+const enMessages = require('../src/static/_locales/en/messages.json');
+const jaMessages = require('../src/static/_locales/ja/messages.json');
+
 const pathToExtension = path.join(__dirname, '..', 'dist');
 
 /**
+ * popup は起動時に曲リストを外部から取得することがある (Constants.PARSED_MUSIC_LIST_URL)。
+ * テストを外部ネットワークに依存させないため、全コンテキストでスタブに差し替える。
+ */
+const MUSIC_LIST_URL_PATTERN = '**/DDRScoreTracker/musics/*';
+const STUB_MUSIC_LIST = ['stubremote0000000000000000000000', '0', '0', '3', '7', '12', '15', '17', '8', '13', '16', '18', '19', 'Stub Remote Song'].join('\t');
+
+/** chart-list.vue が 1 譜面あたりに描画する div の class → 読み出し用のキー */
+const CHART_FIELD_BY_CLASS = {
+  level: 'level',
+  title: 'title',
+  clear_count: 'clearCount',
+  play_count: 'playCount',
+  flare_rank: 'flareRank',
+  flare_skill: 'flareSkill',
+  score_rank: 'scoreRank',
+  full_combo_type: 'fullCombo',
+  score: 'score',
+  max_combo: 'maxCombo',
+};
+
+/**
  * Launch a persistent Chromium context with the extension loaded.
- * Returns { context, userDataDir, extensionId }.
+ * Returns { context, userDataDir, extensionId, musicListRequests }.
  *
  * MV3 の Service Worker を検出するには chromium 本体が必要で、
  * headless の既定である chrome-headless-shell では検出できない。
  * channel: 'chromium' が本体を選ばせる（生の --headless* 引数は渡さないこと。
  * Chrome 側の headless 実装変更に巻き込まれて起動ごと落ちた前例がある → #692）。
  *
- * ローカルで目視したい場合は HEADED=1 yarn test:e2e。
+ * uiLanguage を渡すとロケールを切り替える。_locales のどのメッセージが使われるかは
+ * 環境変数 LANGUAGE でしか変わらず (--lang 引数では変わらない)、
+ * chrome.i18n.getUILanguage() の戻り値は locale オプションでしか変わらないため、両方を渡す。
  */
-async function launchExtensionContext() {
+async function launchExtensionContext({ uiLanguage } = {}) {
   // プロファイルを使い回すと chrome.storage.local が実行を跨いで残り、
   // まっさらな CI と状態が食い違うため、起動ごとに捨てる
   const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ddrst-e2e-'));
@@ -45,6 +74,13 @@ async function launchExtensionContext() {
     headless: process.env.HEADED !== '1',
     channel: 'chromium',
     args: [`--disable-extensions-except=${pathToExtension}`, `--load-extension=${pathToExtension}`, '--no-sandbox', '--disable-setuid-sandbox'],
+    ...(uiLanguage ? { locale: uiLanguage.locale, env: { ...process.env, LANGUAGE: uiLanguage.language } } : {}),
+  });
+
+  const musicListRequests = { count: 0 };
+  await context.route(MUSIC_LIST_URL_PATTERN, async (route) => {
+    musicListRequests.count += 1;
+    await route.fulfill({ status: 200, contentType: 'text/plain', body: STUB_MUSIC_LIST });
   });
 
   // Wait for the service worker to start and get the extension ID
@@ -54,7 +90,7 @@ async function launchExtensionContext() {
   }
 
   const extensionId = background.url().split('/')[2];
-  return { context, userDataDir, extensionId };
+  return { context, userDataDir, extensionId, background, musicListRequests };
 }
 
 /**
@@ -65,7 +101,87 @@ async function closeExtensionContext(context, userDataDir) {
   fs.rmSync(userDataDir, { recursive: true, force: true });
 }
 
-test.describe('Chrome Extension: 拡張機能ロード', () => {
+/**
+ * popup を開く。
+ * browser_action/index.ts は同じ popup が 2 枚開いていると window.close() するため、
+ * 同時に開くページは 1 枚までにすること。
+ */
+async function openPopup(context, extensionId) {
+  const page = await context.newPage();
+  // 1024px 以上ではフィルタが常時表示の 2 ペイン表示になり、開閉ボタンが消える。
+  // 実際の popup に近いドロワー表示側で検証するため、幅を固定する
+  await page.setViewportSize({ width: 800, height: 600 });
+  await page.goto(`chrome-extension://${extensionId}/browser_action/index.html`);
+  return page;
+}
+
+async function openOptions(context, extensionId) {
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/options_ui/index.html`);
+  return page;
+}
+
+/**
+ * chrome.storage.local に書き込む。
+ *
+ * popup ではなく Service Worker から書くこと。popup を開いた時点で App が
+ * 曲リストの自動取得を始めることがあり、その非同期な保存が後から
+ * 投入データを上書きしてしまうため (browser_action/index.ts の refresh-chart-list)。
+ */
+async function seedStorage(background, data) {
+  await background.evaluate(async (payload) => {
+    await chrome.storage.local.set(payload);
+  }, data);
+}
+
+/** chrome.storage.local から読み出す */
+async function readStorage(background, defaults) {
+  return background.evaluate(async (query) => chrome.storage.local.get(query), defaults);
+}
+
+/** 描画されている譜面一覧を、1 譜面 1 オブジェクトに組み立てて返す */
+async function readCharts(page) {
+  return page.$$eval(
+    '#app-charts .score_list > div',
+    (elements, fieldByClass) => {
+      const charts = [];
+      let current = null;
+      elements.forEach((element) => {
+        const [className, modifier] = element.className.split(' ');
+        const field = fieldByClass[className];
+        if (field === undefined) {
+          return;
+        }
+        if (field === 'level') {
+          current = {};
+          charts.push(current);
+        }
+        if (current === null) {
+          return;
+        }
+        current[field] = (element.textContent ?? '').trim();
+        if (modifier !== undefined) {
+          current[`${field}Class`] = modifier;
+        }
+      });
+      return charts;
+    },
+    CHART_FIELD_BY_CLASS
+  );
+}
+
+/** フィルタのドロワーを開く (閉じたままだと input を操作できない) */
+async function openFilterDrawer(page) {
+  await page.locator('#openFilterButton').click();
+  await expect(page.locator('#filterContainer')).toHaveClass(/active/);
+}
+
+/** 描画完了を待つ。title は 1 譜面につき 1 つ描画される */
+async function expectChartCount(page, count) {
+  await expect(page.locator('#app-charts .score_list > div.title')).toHaveCount(count);
+}
+
+test.describe('拡張機能のロード', () => {
   let context;
   let userDataDir;
   let extensionId;
@@ -78,108 +194,252 @@ test.describe('Chrome Extension: 拡張機能ロード', () => {
     await closeExtensionContext(context, userDataDir);
   });
 
-  test('Service Worker が起動し拡張機能 ID が取得できる', () => {
+  test('MV3 の Service Worker が起動し、拡張機能 ID が取得できる', () => {
     expect(extensionId).toMatch(/^[a-z]{32}$/);
   });
 
-  test('browser_action ページが表示される', async () => {
-    const page = await context.newPage();
-    await page.goto(`chrome-extension://${extensionId}/browser_action/index.html`);
-    await expect(page.locator('body')).toBeVisible({ timeout: 10000 });
-    await page.close();
-  });
-
-  test('browser_action ページのタイトルまたは主要要素が存在する', async () => {
-    const page = await context.newPage();
-    await page.goto(`chrome-extension://${extensionId}/browser_action/index.html`);
-
-    // Wait for Vue to mount and render the app
-    await page.waitForLoadState('domcontentloaded');
-
-    // The page should have at least a body element
-    const body = await page.locator('body').innerHTML();
-    expect(body.length).toBeGreaterThan(0);
-    await page.close();
+  test('Service Worker が background/main.js として動いている', () => {
+    const [background] = context.serviceWorkers();
+    expect(background.url()).toBe(`chrome-extension://${extensionId}/background/main.js`);
   });
 });
 
-test.describe('Chrome Extension: browser_action UI', () => {
+test.describe('browser_action: chrome.storage.local のデータ描画', () => {
   let context;
   let userDataDir;
   let extensionId;
+  let background;
   let page;
 
   test.beforeAll(async () => {
-    ({ context, userDataDir, extensionId } = await launchExtensionContext());
+    ({ context, userDataDir, extensionId, background } = await launchExtensionContext());
+    await seedStorage(background, createStorageFixture());
+    page = await openPopup(context, extensionId);
+    await expectChartCount(page, EXPECTED_SINGLE_CHARTS.length);
   });
 
   test.afterAll(async () => {
     await closeExtensionContext(context, userDataDir);
   });
 
-  test.beforeEach(async () => {
-    page = await context.newPage();
-    await page.goto(`chrome-extension://${extensionId}/browser_action/index.html`);
-    await page.waitForLoadState('domcontentloaded');
+  test('投入した楽曲の SP 譜面がすべて描画される', async () => {
+    const charts = await readCharts(page);
+    const rendered = charts.map((chart) => ({ title: chart.title, level: chart.level })).sort((a, b) => (a.title + a.level).localeCompare(b.title + b.level));
+    const expected = [...EXPECTED_SINGLE_CHARTS].sort((a, b) => (a.title + a.level).localeCompare(b.title + b.level));
+    expect(rendered).toEqual(expected);
   });
 
-  test.afterEach(async () => {
-    await page.close();
+  test('削除済みでスコアのない楽曲は既定の availability フィルタで除外される', async () => {
+    const charts = await readCharts(page);
+    expect(charts.map((chart) => chart.title)).not.toContain('E2E Deleted');
   });
 
-  test('初期状態でページが読み込まれる', async () => {
-    await expect(page.locator('body')).toBeVisible();
-  });
-
-  test('#app-charts 要素が存在する', async () => {
-    // The chart list container should be rendered by Vue
-    await expect(page.locator('#chart-list #app-charts')).toBeVisible({ timeout: 5000 });
-  });
-
-  test('chrome.storage.local にデータを注入後に再読み込みするとチャートが表示される', async () => {
-    // Inject test data into chrome.storage.local
-    await page.evaluate(async () => {
-      // Create minimal score list entry that the extension can display
-      const testData = {
-        scoreListVersion: '1',
-        lastUpdated: Date.now(),
-      };
-      await chrome.storage.local.set(testData);
+  test('スコアを持つ譜面がスコア・ランク・プレー回数を実値で描画する', async () => {
+    const charts = await readCharts(page);
+    const scored = charts.find((chart) => chart.level === SCORED_CHART.level);
+    expect(scored).toMatchObject({
+      title: SCORED_CHART.title,
+      score: SCORED_CHART.score,
+      scoreRank: SCORED_CHART.scoreRank,
+      scoreRankClass: SCORED_CHART.scoreRankClass,
+      clearCount: SCORED_CHART.clearCount,
+      playCount: SCORED_CHART.playCount,
+      maxCombo: SCORED_CHART.maxCombo,
+      flareRank: SCORED_CHART.flareRank,
+      flareRankClass: SCORED_CHART.flareRankClass,
+      flareSkill: SCORED_CHART.flareSkill,
+      fullCombo: SCORED_CHART.fullCombo,
+      fullComboClass: SCORED_CHART.fullComboClass,
     });
+  });
 
-    // Reload the page
-    await page.reload();
-    await page.waitForLoadState('domcontentloaded');
+  test('既定のソート (スコア降順) によりスコアを持つ譜面が先頭に来る', async () => {
+    const charts = await readCharts(page);
+    expect(charts[0].level).toBe(SCORED_CHART.level);
+    expect(charts[0].score).toBe(SCORED_CHART.score);
+  });
 
-    // Page should still render without errors after data injection
-    await expect(page.locator('body')).toBeVisible();
+  test('スコアのない譜面はスコア関連の欄が空で描画される', async () => {
+    const charts = await readCharts(page);
+    const notPlayed = charts.find((chart) => chart.title === 'E2E Beta' && chart.level === "13'");
+    expect(notPlayed).toMatchObject({ score: '', scoreRank: '', clearCount: '', playCount: '', maxCombo: '' });
   });
 });
 
-test.describe('Chrome Extension: options_ui ページ', () => {
+test.describe('browser_action: フィルタ', () => {
   let context;
   let userDataDir;
   let extensionId;
+  let background;
+  let page;
 
-  test.beforeAll(async () => {
-    ({ context, userDataDir, extensionId } = await launchExtensionContext());
+  test.beforeEach(async () => {
+    ({ context, userDataDir, extensionId, background } = await launchExtensionContext());
+    await seedStorage(background, createStorageFixture());
+    page = await openPopup(context, extensionId);
+    await expectChartCount(page, EXPECTED_SINGLE_CHARTS.length);
   });
 
-  test.afterAll(async () => {
+  test.afterEach(async () => {
     await closeExtensionContext(context, userDataDir);
   });
 
-  test('options ページが存在し表示される', async () => {
-    const page = await context.newPage();
-    // Try to load the options page (it might be at options_ui/index.html or similar)
+  test('playMode を DP に切り替えると DP 譜面だけが描画される', async () => {
+    await openFilterDrawer(page);
+    await page.locator('#filterCondition_playMode_1').check();
+
+    await expectChartCount(page, EXPECTED_DOUBLE_CHARTS.length);
+    const charts = await readCharts(page);
+    const rendered = charts.map((chart) => ({ title: chart.title, level: chart.level })).sort((a, b) => (a.title + a.level).localeCompare(b.title + b.level));
+    const expected = [...EXPECTED_DOUBLE_CHARTS].sort((a, b) => (a.title + a.level).localeCompare(b.title + b.level));
+    expect(rendered).toEqual(expected);
+  });
+
+  test('level フィルタで絞り込むと該当する譜面だけが残る', async () => {
+    await openFilterDrawer(page);
+    await page.locator('#filterCondition_level_15').check();
+
+    await expectChartCount(page, 1);
+    const charts = await readCharts(page);
+    expect(charts[0]).toMatchObject({ title: 'E2E Alpha', level: "15'" });
+  });
+
+  test('フィルタ条件が chrome.storage.local に永続化され、再読み込み後も復元される', async () => {
+    await openFilterDrawer(page);
+    await page.locator('#filterCondition_level_15').check();
+    await expectChartCount(page, 1);
+
+    const { conditions } = await readStorage(background, { conditions: null });
+    expect(conditions.filter).toContainEqual({ attribute: 'level', values: [15] });
+
+    await page.reload();
+
+    // 再読み込み後もチェック状態と絞り込み結果が維持されている
+    await expect(page.locator('#filterCondition_level_15')).toBeChecked();
+    await expectChartCount(page, 1);
+    const charts = await readCharts(page);
+    expect(charts[0]).toMatchObject({ title: 'E2E Alpha', level: "15'" });
+  });
+});
+
+test.describe('chrome.i18n によるロケール解決', () => {
+  /**
+   * data-i18n-key を持つ要素は i18n4html.js が chrome.i18n.getMessage で埋める。
+   * 置換用のプレースホルダを含むメッセージは静的な比較ができないため対象外にする。
+   */
+  async function collectTranslations(page) {
+    return page.$$eval('[data-i18n-key]', (elements) =>
+      elements.map((element) => ({
+        key: element.getAttribute('data-i18n-key'),
+        text: (element.textContent ?? '').trim(),
+      }))
+    );
+  }
+
+  function assertTranslated(translations, messages, locale) {
+    const targets = translations.filter(({ key }) => messages[key] !== undefined && !messages[key].message.includes('$'));
+    // 比較対象が消えてしまうと素通りしてしまうため、十分な数を見ていることを担保する
+    expect(targets.length).toBeGreaterThan(10);
+    targets.forEach(({ key, text }) => {
+      expect(text, `${locale}: ${key}`).toBe(messages[key].message.trim());
+    });
+    translations.forEach(({ key, text }) => {
+      expect(messages[key], `${locale} の messages.json に ${key} がない`).toBeDefined();
+      expect(text, `${locale}: ${key} が未解決`).not.toBe('');
+      expect(text, `${locale}: ${key} が未解決`).not.toBe(key);
+    });
+  }
+
+  test('UI ロケールが en のとき en/messages.json の文言が描画される', async () => {
+    const { context, userDataDir, extensionId } = await launchExtensionContext();
     try {
-      await page.goto(`chrome-extension://${extensionId}/options_ui/index.html`, { timeout: 5000 });
-      await expect(page.locator('body')).toBeVisible();
-    } catch {
-      // Options page might not exist at this path - that's acceptable
-      // The test passes if we can at least navigate without a crash
+      const page = await openPopup(context, extensionId);
+      expect(await page.evaluate(() => chrome.i18n.getUILanguage())).toMatch(/^en/);
+      assertTranslated(await collectTranslations(page), enMessages, 'en');
     } finally {
-      await page.close();
+      await closeExtensionContext(context, userDataDir);
     }
+  });
+
+  test('UI ロケールが ja のとき ja/messages.json の文言が描画される', async () => {
+    const { context, userDataDir, extensionId } = await launchExtensionContext({ uiLanguage: { locale: 'ja-JP', language: 'ja' } });
+    try {
+      const page = await openPopup(context, extensionId);
+      expect(await page.evaluate(() => chrome.i18n.getUILanguage())).toMatch(/^ja/);
+      assertTranslated(await collectTranslations(page), jaMessages, 'ja');
+    } finally {
+      await closeExtensionContext(context, userDataDir);
+    }
+  });
+});
+
+test.describe('options_ui', () => {
+  let context;
+  let userDataDir;
+  let extensionId;
+  let background;
+  let musicListRequests;
+
+  test.beforeEach(async () => {
+    ({ context, userDataDir, extensionId, background, musicListRequests } = await launchExtensionContext());
+  });
+
+  test.afterEach(async () => {
+    await closeExtensionContext(context, userDataDir);
+  });
+
+  test('保存済みの options がフォームに反映される', async () => {
+    await seedStorage(background, { options: { enableDebugLog: true, openTabAsActive: true, musicListReloadInterval: 3600000 } });
+    const page = await openOptions(context, extensionId);
+
+    await expect(page.locator('[name=enableDebugLog]')).toBeChecked();
+    await expect(page.locator('[name=openTabAsActive]')).toBeChecked();
+    await expect(page.locator('[name=notCloseTabAfterUse]')).not.toBeChecked();
+    await expect(page.locator('[name=musicListReloadInterval]')).toHaveValue('3600000');
+  });
+
+  test('チェックボックスの変更が chrome.storage.local に保存され、再読み込み後も復元される', async () => {
+    const page = await openOptions(context, extensionId);
+    await expect(page.locator('[name=enableDebugLog]')).not.toBeChecked();
+
+    await page.locator('[name=enableDebugLog]').check();
+
+    await expect
+      .poll(async () => {
+        const { options } = await readStorage(background, { options: {} });
+        return options.enableDebugLog;
+      })
+      .toBe(true);
+
+    await page.reload();
+    await expect(page.locator('[name=enableDebugLog]')).toBeChecked();
+  });
+
+  test('musicListReloadInterval を 0 にすると popup が曲リストを取得しなくなる', async () => {
+    // 既定値 (86400000) では、未取得 (musicListUpdatedAt=0) の popup は曲リストを取りに行く
+    await seedStorage(background, { internalStatus: { musicListUpdatedAt: 0 } });
+    const popup = await openPopup(context, extensionId);
+    await expect.poll(() => musicListRequests.count).toBeGreaterThan(0);
+    await popup.close();
+
+    // options 画面で自動取得を無効にする
+    const options = await openOptions(context, extensionId);
+    await options.locator('[name=musicListReloadInterval]').fill('0');
+    await options.locator('[name=musicListReloadInterval]').press('Tab');
+    await expect
+      .poll(async () => {
+        const { options: saved } = await readStorage(background, { options: {} });
+        return saved.musicListReloadInterval;
+      })
+      .toBe(0);
+    await options.close();
+    // 取得に成功すると musicListUpdatedAt が「今」に更新され、
+    // 次回は間隔に関係なく取得しなくなる。設定の効果だけを見るため 0 に戻す
+    await seedStorage(background, { internalStatus: { musicListUpdatedAt: 0 } });
+
+    const requestsBefore = musicListRequests.count;
+    const popupAgain = await openPopup(context, extensionId);
+    await expect(popupAgain.locator('#app-charts')).toBeAttached();
+    expect(musicListRequests.count).toBe(requestsBefore);
   });
 });

--- a/test-e2e/fixtures/test-data.js
+++ b/test-e2e/fixtures/test-data.js
@@ -1,80 +1,147 @@
 /**
  * Fixture data for Playwright E2E tests.
  *
- * This module exports pre-built chrome.storage.local data that can be
- * injected into the extension during tests via page.evaluate().
+ * chrome.storage.local に直接投入するための、実際の保存フォーマットのデータ。
+ * 各キーの形は以下の実装に対応する:
+ *   musics  → MusicList.createFromStorage / MusicData.createFromStorage
+ *   scores  → ScoreList.createFromStorage / ScoreData.createFromStorage / ScoreDetail.createFromStorage
+ *
+ * difficulty 配列は 9 要素で、添字は Util.getDifficultyValue(playMode, difficulty) と一致する。
+ *   [0..4] = SP BEGINNER / BASIC / DIFFICULT / EXPERT / CHALLENGE
+ *   [5..8] = DP BASIC / DIFFICULT / EXPERT / CHALLENGE  (DP に BEGINNER はない)
+ * 値 0 は「その譜面が存在しない」を意味する (MusicData.hasDifficulty)。
  */
 
 'use strict';
 
+const MUSIC_ALPHA_ID = 'e2ealpha00000000000000000000000a';
+const MUSIC_BETA_ID = 'e2ebeta000000000000000000000000b';
+const MUSIC_DELETED_ID = 'e2edeleted0000000000000000000000';
+
+/** 全難易度を持つ楽曲。SP EXPERT にだけスコアがある */
+const MUSIC_ALPHA = {
+  musicId: MUSIC_ALPHA_ID,
+  type: 0, // MUSIC_TYPE.NORMAL
+  title: 'E2E Alpha',
+  difficulty: [3, 7, 12, 15, 17, 8, 13, 16, 18],
+  isDeleted: 0,
+  containedVersion: 19,
+};
+
+/** CHALLENGE 譜面を持たない楽曲。スコアはない */
+const MUSIC_BETA = {
+  musicId: MUSIC_BETA_ID,
+  type: 0,
+  title: 'E2E Beta',
+  difficulty: [2, 5, 9, 13, 0, 6, 10, 14, 0],
+  isDeleted: 0,
+  containedVersion: 18,
+};
+
+/** 削除済み楽曲。スコアがないので availability=2 となり、既定のフィルタで除外される */
+const MUSIC_DELETED = {
+  musicId: MUSIC_DELETED_ID,
+  type: 0,
+  title: 'E2E Deleted',
+  difficulty: [1, 4, 8, 11, 0, 5, 9, 12, 0],
+  isDeleted: 1,
+  containedVersion: 12,
+};
+
+const MUSICS = {
+  [MUSIC_ALPHA_ID]: MUSIC_ALPHA,
+  [MUSIC_BETA_ID]: MUSIC_BETA,
+  [MUSIC_DELETED_ID]: MUSIC_DELETED,
+};
+
+/** difficulty のキー 3 は Util.getDifficultyValue(SINGLE, EXPERT) */
+const SCORES = {
+  [MUSIC_ALPHA_ID]: {
+    musicId: MUSIC_ALPHA_ID,
+    musicType: 0,
+    difficulty: {
+      3: {
+        score: 987650,
+        scoreRank: 15, // SCORE_RANK.AA_PLUS
+        clearType: 6, // CLEAR_TYPE.GREAT_FC
+        playCount: 12,
+        clearCount: 10,
+        flareRank: 7, // FLARE_RANK.FLARE_7
+        flareSkill: 1234,
+        maxCombo: 456,
+      },
+    },
+  },
+};
+
 /**
- * Minimal music list entry encoded for storage.
- * These represent parsed MusicData objects in their storage format.
+ * SP EXPERT の E2E Alpha が画面上でどう描画されるかの期待値。
+ * ChartData の各 getter (scoreString / scoreRankString / flareRankSymbol など) の出力に対応する。
  */
-const MUSIC_LIST_ENTRIES = [
-  {
-    musicId: 'test001',
-    title: 'Test Song Alpha',
-    artist: 'Test Artist',
-    bpm: '180',
-    levels: { 1: 10, 2: 14, 3: 16, 4: 18 },
-    musicType: 0,
-  },
-  {
-    musicId: 'test002',
-    title: 'Test Song Beta',
-    artist: 'Another Artist',
-    bpm: '140',
-    levels: { 1: 8, 2: 12, 3: 15, 4: null },
-    musicType: 0,
-  },
+const SCORED_CHART = {
+  title: 'E2E Alpha',
+  level: "15'", // levelString + playModeSymbol(SINGLE)
+  clearCount: '10/',
+  playCount: '12',
+  flareRank: 'Ⅶ',
+  flareRankClass: 'flare_7',
+  flareSkill: '1234',
+  scoreRank: 'AA+',
+  scoreRankClass: 'rank_aa_p',
+  fullCombo: '○',
+  fullComboClass: 'great_fc',
+  score: '987,650',
+  maxCombo: '/456',
+};
+
+/** 既定のフィルタ (playMode=SP, availability=0) で描画されるはずの譜面 */
+const EXPECTED_SINGLE_CHARTS = [
+  { title: 'E2E Alpha', level: "3'" },
+  { title: 'E2E Alpha', level: "7'" },
+  { title: 'E2E Alpha', level: "12'" },
+  { title: 'E2E Alpha', level: "15'" },
+  { title: 'E2E Alpha', level: "17'" },
+  { title: 'E2E Beta', level: "2'" },
+  { title: 'E2E Beta', level: "5'" },
+  { title: 'E2E Beta', level: "9'" },
+  { title: 'E2E Beta', level: "13'" },
+];
+
+/** playMode を DP に切り替えたときに描画されるはずの譜面 */
+const EXPECTED_DOUBLE_CHARTS = [
+  { title: 'E2E Alpha', level: '8"' },
+  { title: 'E2E Alpha', level: '13"' },
+  { title: 'E2E Alpha', level: '16"' },
+  { title: 'E2E Alpha', level: '18"' },
+  { title: 'E2E Beta', level: '6"' },
+  { title: 'E2E Beta', level: '10"' },
+  { title: 'E2E Beta', level: '14"' },
 ];
 
 /**
- * Minimal score data for a single chart.
- * Mirrors the ScoreData storage format.
+ * chrome.storage.local に投入するデータ一式を返す。
+ *
+ * internalStatus.musicListUpdatedAt を「今」にしているのは、popup が起動時に
+ * 曲リストを再取得してフィクスチャを上書きしてしまうのを防ぐため
+ * (browser_action/index.ts の refresh-chart-list ハンドラを参照)。
  */
-const SCORE_ENTRIES = [
-  {
-    musicId: 'test001',
-    playMode: 0,
-    difficulty: 3,
-    score: 980000,
-    clearType: 3,
-    flareRank: 5,
-    flareSkill: 1234,
-    maxCombo: 280,
-    clearCount: 5,
-    playCount: 10,
-  },
-  {
-    musicId: 'test002',
-    playMode: 0,
-    difficulty: 2,
-    score: 850000,
-    clearType: 3,
-    flareRank: 3,
-    flareSkill: 900,
-    maxCombo: 200,
-    clearCount: 2,
-    playCount: 4,
-  },
-];
-
-/**
- * Build a storage payload suitable for injection via chrome.storage.local.set().
- * Keys follow the convention used by Storage.js.
- */
-function buildStoragePayload() {
+function createStorageFixture(overrides = {}) {
   return {
-    musicList: JSON.stringify(MUSIC_LIST_ENTRIES),
-    scoreData: JSON.stringify(SCORE_ENTRIES),
-    options: JSON.stringify({
-      gameVersion: 2,
-      enableDebugLog: false,
-      language: 'en',
-    }),
+    musics: MUSICS,
+    scores: SCORES,
+    internalStatus: { musicListUpdatedAt: Date.now() },
+    ...overrides,
   };
 }
 
-module.exports = { MUSIC_LIST_ENTRIES, SCORE_ENTRIES, buildStoragePayload };
+module.exports = {
+  MUSIC_ALPHA,
+  MUSIC_BETA,
+  MUSIC_DELETED,
+  MUSICS,
+  SCORES,
+  SCORED_CHART,
+  EXPECTED_SINGLE_CHARTS,
+  EXPECTED_DOUBLE_CHARTS,
+  createStorageFixture,
+};


### PR DESCRIPTION
## 概要

#714 で E2E を CI に載せたが、テストの中身は「拡張機能がロードできる」以上のことを検証していなかった。検証対象を **jsdom のコンポーネントテストでは代替できない層**に絞って作り直す。

7 件 → 15 件。

## 何が問題だったか

| 旧テスト | 実際のアサーション |
|---|---|
| browser_action ページが表示される | `body` が visible |
| ページのタイトルまたは主要要素が存在する | `body.innerHTML.length > 0` |
| `#app-charts` 要素が存在する | 要素の存在のみ |
| storage にデータを注入後に再読み込みするとチャートが表示される | **チャートを一切検証せず** `body` が visible。投入データも表示に関係しない 2 キーのみ |
| options ページが存在し表示される | try/catch で握りつぶしており、**失敗しても必ずパスする** |

`test-e2e/fixtures/test-data.js` は保存キー名 (`musicList` / `scoreData`) も形式 (JSON 文字列) も実装と無関係で、かつどこからも import されていなかった。

`test/browser_action/*.test.js` (jsdom + @vue/test-utils) が描画ロジックを担保している一方、それらは `I18n` や `Constants` をモックに差し替えているため、**実 `chrome.*` API を通る経路は誰も検証していない**。E2E の価値はそこにある。

## 追加した検証

| describe | 内容 |
|---|---|
| 拡張機能のロード | Service Worker の起動と拡張機能 ID / SW が `background/main.js` であること |
| storage のデータ描画 | 実フォーマットで投入した楽曲の SP 譜面 9 件が一致 / 削除済み楽曲が既定の `availability` フィルタで除外される / スコアを持つ譜面が実値 (`987,650` `AA+` `rank_aa_p` `Ⅶ` `○` `great_fc` `10/` `12` `/456`) で描画される / 既定のソート (スコア降順) / 未プレー譜面は関連欄が空 |
| フィルタ | DP に切り替えると DP 譜面 7 件になる / level フィルタで 1 件に絞られる / 条件が `chrome.storage.local` に永続化され、再読み込み後もチェック状態と絞り込み結果が復元される |
| chrome.i18n | en / ja それぞれで `_locales/*/messages.json` と DOM の全 `data-i18n-key` 要素を突き合わせる。messages.json 側のキー欠落と未解決 (キー名がそのまま出ている) も検出する |
| options_ui | 保存済み options のフォーム反映 / 変更の永続化と再読み込み後の復元 / **`musicListReloadInterval` を 0 にすると popup が曲リストを取得しなくなる** |

`fixtures/test-data.js` は実際の保存フォーマット (`musics` / `scores` → `MusicData.createFromStorage` / `ScoreData.createFromStorage`) に書き直し、期待される描画結果も併せて持たせた。

## アサーションが空虚でないことの確認

意図的に壊して、落ちることを確認した。

| 改変 | 結果 |
|---|---|
| 期待スコアを `987,650` → `987650` に改変 | ✘ 失敗 |
| `en/messages.json` の文言だけ変更 (dist は再ビルドしない) | ✘ 失敗 |
| options で 0 に設定せず既定値のままにする | ✘ 失敗 (＝取得が起きることを検知できている) |

## 実装調査で判明した落とし穴

いずれもテスト側で対処し、理由をコメントに残した。

1. **popup を開くと曲リストの外部取得が走る**。空 storage で popup を開くと `refresh-chart-list` ハンドラが `fetchParsedMusicList()` を呼び、その非同期な保存が後からフィクスチャを上書きしていた (最初は投入したはずの曲が描画されず、代わりに取得結果が 5 譜面表示されていた)。storage の投入を popup ではなく **Service Worker 経由**に変更して解決。
2. 上記の裏返しとして、**従来の E2E は毎回 `ryowatanabe.github.io` に実アクセスしていた**。取得先を `context.route()` でスタブに差し替え、テストを外部ネットワークに依存させないようにした。
3. **`chrome.i18n` のロケール切替は 2 系統**。`_locales` のどれが使われるかは環境変数 `LANGUAGE` でしか変わらず (`--lang` 引数では変わらない)、`chrome.i18n.getUILanguage()` の戻り値は Playwright の `locale` オプションでしか変わらない。両方渡している。
4. **1024px 以上ではフィルタが常時表示の 2 ペインになり**、ドロワーの開閉ボタンが消える。popup の viewport を 800x600 に固定してドロワー表示側で検証している。

## 確認

- `yarn test:e2e` → 15 passed (8.1s)、`CI=1` でも同じ
- `yarn test` → 578 passed / `yarn tsc --noEmit` / `yarn lint` / `prettier` いずれもパス

Closes #715

🤖 Generated with [Claude Code](https://claude.com/claude-code)